### PR TITLE
Wrap *Common classes into an unnamed namespace

### DIFF
--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -834,6 +834,7 @@ class CodeGenerator:
 
     def generate_common_classes(self, i):
         self.emit_h_common(dedent("""
+        namespace {{
         class {i.cpp_class_name}Common {{
             public:
                 template<typename T>
@@ -863,6 +864,7 @@ class CodeGenerator:
                     return newStrv;
                 }}
         }};
+        }} // namespace
         class {i.cpp_class_name}MessageHelper {{
         public:
             {i.cpp_class_name}MessageHelper (const Glib::RefPtr<Gio::DBus::MethodInvocation> msg) :


### PR DESCRIPTION
This avoid naming conflicts in case the project has declared a namespace
(or even a class) having the same name as the generated *Common class.

Signed-off-by: Alberto Mardegan <amardegan@luxoft.com>