### PR TITLE
Wrap *MessageHelper into same namespace as *Common

### DIFF
--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -864,7 +864,7 @@ class CodeGenerator:
                     return newStrv;
                 }}
         }};
-        }} // namespace
+
         class {i.cpp_class_name}MessageHelper {{
         public:
             {i.cpp_class_name}MessageHelper (const Glib::RefPtr<Gio::DBus::MethodInvocation> msg) :
@@ -921,6 +921,7 @@ class CodeGenerator:
         private:
             Glib::RefPtr<Gio::DBus::MethodInvocation> m_message;
         };
+        } // namespace
         """))
 
 


### PR DESCRIPTION
The *MessageHelper classes uses corresponding *Common class, and if
there is a class or namespace with the same name as the *Common class
*MessageHelper will pick up the right thing if it is in the same
unnamed namespace.

Signed-off-by: Erik Botö <erik.boto@pelagicore.com>