### PR TITLE
Add support for more complex types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
-language: python
-python:
-    - "2.7"
+sudo: required
+services:
+    - docker
 before_install:
-    - sudo apt-get -qq update
-    - sudo apt-get install -y libglibmm-2.4-dev
+    - docker pull ubuntu:18.04
+    - docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/home/gdbus-codegen-glibmm -td ubuntu:18.04 /bin/bash
+    - docker exec -ti travis-ci bash -c "apt-get -qq update"
+    - docker exec -ti travis-ci bash -c "apt-get install -y cmake dbus-test-runner libglibmm-2.4-dev python-setuptools"
 install:
-    - python ./setup.py install
+    - docker exec -ti travis-ci bash -c "cd /home/gdbus-codegen-glibmm && python2.7 ./setup.py install"
 script:
-    - cd test && ./runtests.sh
+    - docker exec travis-ci bash -c "cd /home/gdbus-codegen-glibmm/test && dbus-test-runner -t ./runtests.sh"
+after_script:
+    - docker stop travis-ci

--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -170,7 +170,7 @@ class CodeGenerator:
                                 self.emit_h_p("        %s_variantValue = Glib::Variant<Glib::Variant<T> >::create(Glib::Variant<T>::create(%s_param));" % (a.name, a.name))
                                 self.emit_h_p("        params.push_back(%s_variantValue);" % (a.name))
                             else:
-                                self.emit_h_p("        " + a.cpptype_send(a.name + "_param", a.name, i.cpp_class_name) + "")
+                                self.emit_h_p("        " + a.cppvalue_send(a.name + "_param", a.name, i.cpp_class_name) + "")
                                 self.emit_h_p("        params.push_back(%s_param);" % (a.name))
                     elif (len(m.in_args) == 1):
                         for a in m.in_args:
@@ -179,7 +179,7 @@ class CodeGenerator:
                                 self.emit_h_p("        variantValue = Glib::Variant<Glib::Variant<T> >::create(Glib::Variant<T>::create(%s));" % (a.name))
                                 self.emit_h_p("        Glib::VariantBase params = variantValue;")
                             else:
-                                self.emit_h_p("        " + a.cpptype_send("params", a.name, i.cpp_class_name) + "")
+                                self.emit_h_p("        " + a.cppvalue_send("params", a.name, i.cpp_class_name) + "")
                     if (len(m.in_args) > 0):
                         self.emit_h_p("        base = Glib::VariantContainerBase::create_tuple(params);")
 
@@ -277,11 +277,11 @@ class CodeGenerator:
                 if (len(m.in_args) > 1):
                     self.emit_cpp_p("std::vector<Glib::VariantBase> params;")
                     for a in m.in_args:
-                        self.emit_cpp_p("  " + a.cpptype_send(a.name + "_param", a.name, i.cpp_class_name)+ "")
+                        self.emit_cpp_p("  " + a.cppvalue_send(a.name + "_param", a.name, i.cpp_class_name)+ "")
                         self.emit_cpp_p("  params.push_back(%s_param);" % a.name)
                 elif (len (m.in_args) == 1):
                     for a in m.in_args:
-                        self.emit_cpp_p("    " + a.cpptype_send("params", a.name, i.cpp_class_name) + "")
+                        self.emit_cpp_p("    " + a.cppvalue_send("params", a.name, i.cpp_class_name) + "")
 
                 if (len(m.in_args) > 0):
                     self.emit_cpp_p("    base = Glib::VariantContainerBase::create_tuple(params);")

--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -853,6 +853,7 @@ class CodeGenerator:
         self.emit_h_common(dedent("""
         #pragma once
         #include <iostream>
+        #include <map>
         #include "glibmm.h"
         #include "giomm.h"
         """))

--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -142,7 +142,7 @@ class CodeGenerator:
                     if a.templated:
                         templated = True
 
-                if templated is True:
+                if templated:
                     # Template methods needs to be implemented in the header
 
                     # Begin method signature

--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -139,7 +139,7 @@ class CodeGenerator:
                 # Flag method as templated if there is a variant arg
                 templated = False
                 for a in m.in_args:
-                    if "v" in a.signature:
+                    if a.templated:
                         templated = True
 
                 if templated is True:
@@ -150,7 +150,7 @@ class CodeGenerator:
                     self.emit_h_p("    void %s(" % m.name)
                     for a in m.in_args:
                         # Variants needs special attention
-                        if "v" in a.signature:
+                        if a.templated:
                             self.emit_h_p("        T %s," % (a.name))
                         else:
                             self.emit_h_p("        %s %s," % (a.cpptype_in, a.name))
@@ -165,7 +165,7 @@ class CodeGenerator:
                     if (len(m.in_args) > 1):
                         self.emit_h_p("        std::vector<Glib::VariantBase> params;")
                         for a in m.in_args:
-                            if "v" in a.signature:
+                            if a.templated:
                                 self.emit_h_p("        Glib::Variant<Glib::Variant<T> > %s_variantValue;" % (a.name))
                                 self.emit_h_p("        %s_variantValue = Glib::Variant<Glib::Variant<T> >::create(Glib::Variant<T>::create(%s_param));" % (a.name, a.name))
                                 self.emit_h_p("        params.push_back(%s_variantValue);" % (a.name))
@@ -174,7 +174,7 @@ class CodeGenerator:
                                 self.emit_h_p("        params.push_back(%s_param);" % (a.name))
                     elif (len(m.in_args) == 1):
                         for a in m.in_args:
-                            if "v" in a.signature:
+                            if a.templated:
                                 self.emit_h_p("        Glib::Variant<Glib::Variant<T> > variantValue;")
                                 self.emit_h_p("        variantValue = Glib::Variant<Glib::Variant<T> >::create(Glib::Variant<T>::create(%s));" % (a.name))
                                 self.emit_h_p("        Glib::VariantBase params = variantValue;")
@@ -261,7 +261,7 @@ class CodeGenerator:
             # Flag method as templated if there is a variant arg
             templated = False
             for a in m.in_args:
-                if "v" in a.signature:
+                if a.templated:
                     templated = True
 
             # Only generate code if this is a non-templated method
@@ -663,7 +663,7 @@ class CodeGenerator:
             self.emit_cpp_s("    if (method_name.compare(\"%s\") == 0) {" % m.name)
             for ai in range(len(m.in_args)):
                 a = m.in_args[ai]
-                if a.signature == "v":
+                if a.templated:
                     # Variants are deconstructed differently than the other types
                     self.emit_cpp_s("        Glib::VariantContainerBase containerBase = parameters;")
                     self.emit_cpp_s("        GVariant *output%s;" % (ai))
@@ -931,7 +931,7 @@ class CodeGenerator:
                 # Prepend the class name if this is the generic "TypeWrap" class
                 if cpptype_to_dbus.startswith("TypeWrap"):
                     cpptype_to_dbus = i.cpp_class_name + cpptype_to_dbus
-                if a[index].signature == "v":
+                if a[index].templated:
                     self.emit_h_common("    vlist.push_back(p{index});".format(**locals()))
                 else:
                     self.emit_h_common("    vlist.push_back(Glib::Variant<"+a[index].variant_type+" >::create(" + cpptype_to_dbus + "(p{index})));".format(**locals()))

--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -308,9 +308,8 @@ class CodeGenerator:
 
             for arg_index in range(0, len(m.out_args)):
                 a = m.out_args[arg_index]
-                varname = a.name + "_variant"
                 outvar = "out_" + a.name
-                self.emit_cpp_p("    " + a.cppvalue_get(varname, outvar, str(arg_index), i.cpp_class_name))
+                self.emit_cpp_p("    " + a.cppvalue_get(outvar, str(arg_index), i.cpp_class_name))
                 self.emit_cpp_p("")
             self.emit_cpp_p("}")
             self.emit_cpp_p("")

--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -321,7 +321,7 @@ class CodeGenerator:
                     self.emit_cpp_p(dedent('''
                     {p.cpptype_out} {i.cpp_namespace_name}::{p.name}_get() {{
                         std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
-                        Glib::Variant<{p.cpptype_get} > b;
+                        Glib::Variant<{p.variant_type} > b;
                         if (std::find(props.begin(), props.end(), "{p.name}") != props.end()) {{
                             m_proxy->get_cached_property(b, "{p.name}");
                         }} else {{
@@ -344,7 +344,7 @@ class CodeGenerator:
                         std::vector<Glib::VariantBase> paramsVec;
                         paramsVec.push_back (Glib::Variant<Glib::ustring>::create("{i.name}"));
                         paramsVec.push_back (Glib::Variant<Glib::ustring>::create("{p.name}"));
-                        paramsVec.push_back (Glib::Variant<Glib::VariantBase>::create(Glib::Variant<{p.cpptype_get} >::create({cpptype_to_dbus}(value))));
+                        paramsVec.push_back (Glib::Variant<Glib::VariantBase>::create(Glib::Variant<{p.variant_type} >::create({cpptype_to_dbus}(value))));
                         Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
                         m_proxy->call("org.freedesktop.DBus.Properties.Set",
                                         cb,
@@ -388,9 +388,9 @@ class CodeGenerator:
             for ai in range(len(s.args)):
                 a = s.args[ai]
                 self.emit_cpp_p("        if (parameters.get_n_children() != " + str(len(s.args)) + ") { return; }")
-                self.emit_cpp_p("        Glib::Variant<%s > base_%s;" % (a.cpptype_get, a.name))
+                self.emit_cpp_p("        Glib::Variant<%s > base_%s;" % (a.variant_type, a.name))
                 self.emit_cpp_p("        parameters.get_child(base_%s, %d);" % (a.name, ai))
-                self.emit_cpp_p("        %s p_%s;" % (a.cpptype_get, a.name))
+                self.emit_cpp_p("        %s p_%s;" % (a.variant_type, a.name))
                 self.emit_cpp_p("        p_%s = base_%s.get();" % (a.name, a.name))
                 cpptype_cast = a.cpptype_get_cast
                 # Prepend the class name if this is the generic "TypeWrap" class
@@ -673,9 +673,9 @@ class CodeGenerator:
                     self.emit_cpp_s("        p_%s = Glib::VariantBase(output%s);" % (a.name, ai))
                     self.emit_cpp_s("")
                 else:
-                    self.emit_cpp_s("        Glib::Variant<%s > base_%s;" % (a.cpptype_get, a.name))
+                    self.emit_cpp_s("        Glib::Variant<%s > base_%s;" % (a.variant_type, a.name))
                     self.emit_cpp_s("        parameters.get_child(base_%s, %d);" % (a.name, ai))
-                    self.emit_cpp_s("        %s p_%s;" % (a.cpptype_get, a.name))
+                    self.emit_cpp_s("        %s p_%s;" % (a.variant_type, a.name))
                     self.emit_cpp_s("        p_%s = base_%s.get();" % (a.name, a.name))
                     self.emit_cpp_s("")
             self.emit_cpp_s("        %s(" % m.name)
@@ -709,7 +709,7 @@ class CodeGenerator:
                     cpptype_to_dbus = i.cpp_class_name + cpptype_to_dbus
                 self.emit_cpp_s(dedent('''
                     if (property_name.compare("{p.name}") == 0) {{
-                        property = Glib::Variant<{p.cpptype_get} >::create({cpptype_to_dbus}({p.name}_get()));
+                        property = Glib::Variant<{p.variant_type} >::create({cpptype_to_dbus}({p.name}_get()));
                     }}
                 ''').format(**locals()))
 
@@ -731,7 +731,7 @@ class CodeGenerator:
             self.emit_cpp_s(dedent('''
                 if (property_name.compare("{p.name}") == 0) {{
                     try {{
-                        Glib::Variant<{p.cpptype_get} > castValue = Glib::VariantBase::cast_dynamic<Glib::Variant<{p.cpptype_get} > >(value);
+                        Glib::Variant<{p.variant_type} > castValue = Glib::VariantBase::cast_dynamic<Glib::Variant<{p.variant_type} > >(value);
                         {p.cpptype_out} val;''').format(**locals()))
             cpptype_cast = p.cpptype_get_cast
             # Prepend the class name if this is the generic "TypeWrap" class
@@ -778,7 +778,7 @@ class CodeGenerator:
                 if cpptype_to_dbus.startswith("TypeWrap"):
                     cpptype_to_dbus = i.cpp_class_name + cpptype_to_dbus
                 self.emit_cpp_s(dedent('''
-                paramsList.push_back(Glib::Variant<{a.cpptype_get} >::create({cpptype_to_dbus}({a.name})));;
+                paramsList.push_back(Glib::Variant<{a.variant_type} >::create({cpptype_to_dbus}({a.name})));;
                 ''').format(**locals()))
 
             self.emit_cpp_s(dedent('''      m_connection->emit_signal(
@@ -816,7 +816,7 @@ class CodeGenerator:
             self.emit_cpp_s(dedent('''
             bool {i.cpp_namespace_name}::{p.name}_set({p.cpptype_in} value) {{
                 if ({p.name}_setHandler(value)) {{
-                    Glib::Variant<{p.cpptype_get} > value_get = Glib::Variant<{p.cpptype_get} >::create({cpptype_to_dbus}({p.name}_get()));
+                    Glib::Variant<{p.variant_type} > value_get = Glib::Variant<{p.variant_type} >::create({cpptype_to_dbus}({p.name}_get()));
                     emitSignal("{p.name}", value_get);
                     return true;
                 }}
@@ -935,7 +935,7 @@ class CodeGenerator:
                 if a[index].signature == "v":
                     self.emit_h_common("    vlist.push_back(p{index});".format(**locals()))
                 else:
-                    self.emit_h_common("    vlist.push_back(Glib::Variant<"+a[index].cpptype_get+" >::create(" + cpptype_to_dbus + "(p{index})));".format(**locals()))
+                    self.emit_h_common("    vlist.push_back(Glib::Variant<"+a[index].variant_type+" >::create(" + cpptype_to_dbus + "(p{index})));".format(**locals()))
 
             self.emit_h_common(dedent("""
                 m_message->return_value(Glib::Variant<Glib::VariantBase>::create_tuple(vlist));

--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -854,6 +854,7 @@ class CodeGenerator:
         #pragma once
         #include <iostream>
         #include <map>
+        #include <tuple>
         #include "glibmm.h"
         #include "giomm.h"
         """))

--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -79,7 +79,7 @@ class Type:
         if name == 'cpptype_out':
             return self.cpptype_in
 
-    def cpptype_send(self, name, param, cpp_class_name):
+    def cppvalue_send(self, name, param, cpp_class_name):
         """ Used to create a Variant to be sent over D-Bus """
         t = self.cpptype_get
         return ("Glib::Variant<"+self.cpptype_get+"> "+name+
@@ -106,10 +106,10 @@ class StringType(Type):
             if self.signature == 's':
                 self.cpptype_get_cast = 'Glib::ustring'
 
-    def cpptype_send(self, name, param, cpp_class_name):
+    def cppvalue_send(self, name, param, cpp_class_name):
         print(' self Signature: %s' % (self.signature,))
         if self.signature == 's' or self.signature == 'ay':
-            return Type.cpptype_send(self, name, param, cpp_class_name)
+            return Type.cppvalue_send(self, name, param, cpp_class_name)
         elif self.signature == 'g':
             method = 'create_signature'
         elif self.signature == 'o':
@@ -160,7 +160,7 @@ class ArrayType(Type):
         else:
             return Type.cppvalue_get(self, varname, outvar, idx, cpp_class_name)
 
-    def cpptype_send(self, name, param, cpp_class_name):
+    def cppvalue_send(self, name, param, cpp_class_name):
         if self.signature == 'as':
             return ("Glib::Variant<std::vector<Glib::ustring> > " + name +
                     " = Glib::Variant<std::vector<Glib::ustring> >::create(" +
@@ -172,7 +172,7 @@ class ArrayType(Type):
                     " = Glib::Variant<std::vector< std::string > >::create_from_object_paths(arg_" +
                     param + ");")
         else:
-            return Type.cpptype_send(self, name, param, cpp_class_name)
+            return Type.cppvalue_send(self, name, param, cpp_class_name)
 
 class StructType(Type):
     def __init__(self, signature):

--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -86,8 +86,9 @@ class Type:
         return ("Glib::Variant<"+self.variant_type+"> "+name+
             " = Glib::Variant<"+self.variant_type+">::create(arg_"+param+");")
 
-    def cppvalue_get(self, varname, outvar, idx, cpp_class_name):
+    def cppvalue_get(self, outvar, idx, cpp_class_name):
         """ Used to extract a cpptype_out out of a Variant """
+        varname = outvar + '_v'
         return ("Glib::Variant<"+self.variant_type+"> "+varname+
             ";\n    wrapped.get_child("+varname+","+idx+");\n    "+
             outvar+" = "+varname+".get();")
@@ -125,7 +126,7 @@ class VariantType(Type):
     def __init__(self):
         Type.__init__(self, 'v', 'Glib::VariantBase')
 
-    def cppvalue_get(self, varname, outvar, idx, cpp_class_name):
+    def cppvalue_get(self, outvar, idx, cpp_class_name):
         return 'GVariant *output;\n' +\
                                 '    g_variant_get_child(wrapped.gobj(), 0, "v", &output);\n\n' + "    " + outvar + ' = Glib::VariantBase(output);'
 
@@ -146,7 +147,8 @@ class ArrayType(Type):
             self.variant_type = 'std::vector<std::string>'
             self.cpptype = 'std::vector<std::string>'
 
-    def cppvalue_get(self, varname, outvar, idx, cpp_class_name):
+    def cppvalue_get(self, outvar, idx, cpp_class_name):
+        varname = outvar + '_v'
         if self.signature == 'as':
             return ("Glib::VariantContainerBase "+varname+";\n" +
                     "    wrapped.get_child("+varname+", "+idx+");\n" +
@@ -160,7 +162,7 @@ class ArrayType(Type):
                     "    wrapped.get_child("+varname+", "+idx+");\n" +
                     "    " + cpp_class_name + "TypeWrap::unwrapList("+outvar+", "+varname+");")
         else:
-            return Type.cppvalue_get(self, varname, outvar, idx, cpp_class_name)
+            return Type.cppvalue_get(self, outvar, idx, cpp_class_name)
 
     def cppvalue_send(self, name, param, cpp_class_name):
         if self.signature == 'as':

--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -61,9 +61,9 @@ class Type:
         #   * stub property handler receiving code
         #   * stub signal emission
         #   * stub helper method to return values from method invocations
-        self.cpptype_get = cpptype_in
+        self.variant_type = cpptype_in
 
-        # Used when converting from cpptype_get:
+        # Used when converting from variant_type:
         # - to return value in proxy property getters
         # - when emitting signals in the proxy class
         # - in the stub method handlers, to pass params to the virtual
@@ -72,7 +72,7 @@ class Type:
         #   implementation
         self.cpptype_get_cast = ''
 
-        # Used to cast cpptype_in to cpptype_get when creating variants
+        # Used to cast cpptype_in to variant_type when creating variants
         self.cpptype_to_dbus = ''
 
     def __getattr__(self, name):
@@ -81,9 +81,9 @@ class Type:
 
     def cppvalue_send(self, name, param, cpp_class_name):
         """ Used to create a Variant to be sent over D-Bus """
-        t = self.cpptype_get
-        return ("Glib::Variant<"+self.cpptype_get+"> "+name+
-            " = Glib::Variant<"+self.cpptype_get+">::create(arg_"+param+");")
+        t = self.variant_type
+        return ("Glib::Variant<"+self.variant_type+"> "+name+
+            " = Glib::Variant<"+self.variant_type+">::create(arg_"+param+");")
 
     def cppvalue_get(self, varname, outvar, idx, cpp_class_name):
         """ Used to extract a cpptype_out out of a Variant """
@@ -102,7 +102,7 @@ class StringType(Type):
         signature = 'ay' if signature.startswith('ay') else signature[0]
         Type.__init__(self, signature, 'std::string')
         if self.signature in ('s', 'g', 'o'):
-            self.cpptype_get = 'Glib::ustring'
+            self.variant_type = 'Glib::ustring'
             if self.signature == 's':
                 self.cpptype_get_cast = 'Glib::ustring'
 
@@ -133,15 +133,15 @@ class ArrayType(Type):
         assert signature[0] == 'a'
         self.element = get_type(signature[1:])
         Type.__init__(self, signature[0] + self.element.signature)
-        self.cpptype_get = 'std::vector<' + self.element.cpptype_get + '>'
-        self.cpptype_in = self.cpptype_get
+        self.variant_type = 'std::vector<' + self.element.variant_type + '>'
+        self.cpptype_in = self.variant_type
         if self.signature == 'as':
-            self.cpptype_get = 'std::vector<Glib::ustring>'
+            self.variant_type = 'std::vector<Glib::ustring>'
             self.cpptype_in = 'std::vector<std::string>'
             self.cpptype_get_cast = "TypeWrap::glibStringVecToStdStringVec"
             self.cpptype_to_dbus = "TypeWrap::stdStringVecToGlibStringVec"
         elif self.signature == 'ao':
-            self.cpptype_get = 'std::vector<std::string>'
+            self.variant_type = 'std::vector<std::string>'
             self.cpptype_in = 'std::vector<std::string>'
 
     def cppvalue_get(self, varname, outvar, idx, cpp_class_name):

--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -202,7 +202,7 @@ class DictType(Type):
         assert signature.startswith('a{')
         remaining_signature = signature[2:]
         self.key = get_type(remaining_signature)
-        assert isinstance(self.key, BasicType)
+        assert (isinstance(self.key, BasicType) or isinstance(self.key, StringType))
         remaining_signature = remaining_signature[len(self.key.signature):]
         self.value = get_type(remaining_signature)
         assert self.value is not None
@@ -210,6 +210,9 @@ class DictType(Type):
         assert remaining_signature[0] == '}'
         signature = 'a{' + self.key.signature + self.value.signature + '}'
         Type.__init__(self, signature)
+        self.variant_type = 'std::map<%s,%s>' % (self.key.variant_type,
+                self.value.variant_type)
+        self.cpptype = self.variant_type
 
 
 def get_type(signature):

--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -191,10 +191,13 @@ class StructType(Type):
         while remaining_signature[0] != ')':
             e = get_type(remaining_signature)
             self.elements.append(e)
-            signature.append(e.signature)
+            signature += e.signature
             remaining_signature = remaining_signature[len(e.signature):]
-        signature.append(')')
+        signature += ')'
         Type.__init__(self, signature)
+        type_string = ','.join([t.variant_type for t in self.elements])
+        self.variant_type = 'std::tuple<' + type_string + '>'
+        self.cpptype = self.variant_type
 
 
 class DictType(Type):

--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -87,7 +87,7 @@ class Type:
 
     def cppvalue_get(self, varname, outvar, idx, cpp_class_name):
         """ Used to extract a cpptype_out out of a Variant """
-        return ("Glib::Variant<"+self.cpptype_in+"> "+varname+
+        return ("Glib::Variant<"+self.variant_type+"> "+varname+
             ";\n    wrapped.get_child("+varname+","+idx+");\n    "+
             outvar+" = "+varname+".get();")
 

--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -76,6 +76,9 @@ class Type:
         # Used to cast cpptype_in to variant_type when creating variants
         self.cpptype_to_dbus = ''
 
+        # Tells whether this type must be handled as a template
+        self.templated = False
+
     def __getattr__(self, name):
         if name in ('cpptype_in', 'cpptype_out'):
             return self.cpptype
@@ -125,6 +128,7 @@ class StringType(Type):
 class VariantType(Type):
     def __init__(self):
         Type.__init__(self, 'v', 'Glib::VariantBase')
+        self.templated = True
 
     def cppvalue_get(self, outvar, idx, cpp_class_name):
         return 'GVariant *output;\n' +\

--- a/test/common/many-types.xml
+++ b/test/common/many-types.xml
@@ -42,6 +42,11 @@
         <arg type="ay" name="Param2" direction="out"></arg>
     </method>
 
+    <method name="TestStruct">
+      <arg type="(ss)" name="Param1" direction="in"></arg>
+      <arg type="(ss)" name="Param2" direction="out"></arg>
+    </method>
+
     <method name="TestStructArray">
       <arg type="a(usi)" name="Param1" direction="in"></arg>
       <arg type="a(usi)" name="Param2" direction="out"></arg>

--- a/test/common/many-types.xml
+++ b/test/common/many-types.xml
@@ -47,6 +47,11 @@
       <arg type="a(usi)" name="Param2" direction="out"></arg>
     </method>
 
+    <method name="TestDictStructArray">
+      <arg type="a(sa{sv})" name="Param1" direction="in"></arg>
+      <arg type="a(sa{sv})" name="Param2" direction="out"></arg>
+    </method>
+
     <method name="TestSignature">
         <arg type="g" name="Param1" direction="in"></arg>
         <arg type="g" name="Param2" direction="out"></arg>

--- a/test/common/many-types.xml
+++ b/test/common/many-types.xml
@@ -2,6 +2,21 @@
                       "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
   <interface name="org.gdbus.codegen.glibmm.Test">
+    <method name="TestStringVariantDict">
+      <arg type="a{sv}" name="Param1" direction="in"></arg>
+      <arg type="a{sv}" name="Param2" direction="out"></arg>
+    </method>
+
+    <method name="TestStringStringDict">
+      <arg type="a{ss}" name="Param1" direction="in"></arg>
+      <arg type="a{ss}" name="Param2" direction="out"></arg>
+    </method>
+
+    <method name="TestUintIntDict">
+      <arg type="a{ui}" name="Param1" direction="in"></arg>
+      <arg type="a{ui}" name="Param2" direction="out"></arg>
+    </method>
+
     <method name="TestVariant">
        <arg type="v" name="Param1" direction="in"></arg>
        <arg type="v" name="Param2" direction="out"></arg>

--- a/test/common/many-types.xml
+++ b/test/common/many-types.xml
@@ -42,6 +42,11 @@
         <arg type="ay" name="Param2" direction="out"></arg>
     </method>
 
+    <method name="TestStructArray">
+      <arg type="a(usi)" name="Param1" direction="in"></arg>
+      <arg type="a(usi)" name="Param2" direction="out"></arg>
+    </method>
+
     <method name="TestSignature">
         <arg type="g" name="Param1" direction="in"></arg>
         <arg type="g" name="Param2" direction="out"></arg>

--- a/test/proxy/testproxymain.cpp
+++ b/test/proxy/testproxymain.cpp
@@ -87,6 +87,13 @@ void on_test_string_array_finished (const Glib::RefPtr<Gio::AsyncResult> result,
     printStatus ("String array", res == expected);
 }
 
+void on_test_struct_array_finished (const Glib::RefPtr<Gio::AsyncResult> result,
+                                    std::vector<std::tuple<guint32,Glib::ustring,gint32>> expected) {
+    std::vector<std::tuple<guint32,Glib::ustring,gint32>> res;
+    proxy->TestStructArray_finish(res, result);
+    printStatus ("Struct array", res == expected);
+}
+
 void on_test_byte_string_finished (const Glib::RefPtr<Gio::AsyncResult> result, std::string expected) {
     std::string res;
     proxy->TestByteString_finish(res, result);
@@ -406,6 +413,11 @@ void proxy_created(const Glib::RefPtr<Gio::AsyncResult> result) {
     inputObjPathVec.push_back("/org/gdbus/codegen/glibmm/Test");
     inputObjPathVec.push_back("/org/gdbus/codegen/glibmm/Test");
 
+    std::vector<std::tuple<guint32,Glib::ustring,gint32>> structArray {
+        { 2, "hello world", -3 },
+        { 1, "", 2 },
+    };
+
     std::string bytestring = "Hello world!";
     std::string signatureValue = "b";
     std::string objectPath = "/foo";
@@ -443,6 +455,9 @@ void proxy_created(const Glib::RefPtr<Gio::AsyncResult> result) {
 
     /* String array */
     proxy->TestStringArray(inputObjPathVec, sigc::bind(sigc::ptr_fun(&on_test_string_array_finished), inputObjPathVec));
+
+    /* Struct array */
+    proxy->TestStructArray(structArray, sigc::bind(sigc::ptr_fun(&on_test_struct_array_finished), structArray));
 
     /* Byte string */
     proxy->TestByteString(bytestring, sigc::bind(sigc::ptr_fun(&on_test_byte_string_finished), bytestring));

--- a/test/proxy/testproxymain.cpp
+++ b/test/proxy/testproxymain.cpp
@@ -92,6 +92,13 @@ void on_test_string_array_finished (const Glib::RefPtr<Gio::AsyncResult> result,
     printStatus ("String array", res == expected);
 }
 
+void on_test_struct_finished (const Glib::RefPtr<Gio::AsyncResult> result,
+                              std::tuple<Glib::ustring,Glib::ustring> expected) {
+    std::tuple<Glib::ustring,Glib::ustring> res;
+    proxy->TestStruct_finish(res, result);
+    printStatus ("Struct", res == expected);
+}
+
 void on_test_struct_array_finished (const Glib::RefPtr<Gio::AsyncResult> result,
                                     std::vector<std::tuple<guint32,Glib::ustring,gint32>> expected) {
     std::vector<std::tuple<guint32,Glib::ustring,gint32>> res;
@@ -447,6 +454,10 @@ void proxy_created(const Glib::RefPtr<Gio::AsyncResult> result) {
     inputObjPathVec.push_back("/org/gdbus/codegen/glibmm/Test");
     inputObjPathVec.push_back("/org/gdbus/codegen/glibmm/Test");
 
+    std::tuple<Glib::ustring,Glib::ustring> structure {
+        "one Mississippi", "two Mississippis",
+    };
+
     std::vector<std::tuple<guint32,Glib::ustring,gint32>> structArray {
         { 2, "hello world", -3 },
         { 1, "", 2 },
@@ -497,6 +508,9 @@ void proxy_created(const Glib::RefPtr<Gio::AsyncResult> result) {
 
     /* String array */
     proxy->TestStringArray(inputObjPathVec, sigc::bind(sigc::ptr_fun(&on_test_string_array_finished), inputObjPathVec));
+
+    /* Struct */
+    proxy->TestStruct(structure, sigc::bind(sigc::ptr_fun(&on_test_struct_finished), structure));
 
     /* Struct array */
     proxy->TestStructArray(structArray, sigc::bind(sigc::ptr_fun(&on_test_struct_array_finished), structArray));

--- a/test/stub/teststubmain.cpp
+++ b/test/stub/teststubmain.cpp
@@ -128,6 +128,12 @@ void TestImpl::TestStructArray (
     invocation.ret(Param1);
 }
 
+void TestImpl::TestDictStructArray (
+        std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> Param1,
+        TestMessageHelper invocation) {
+    invocation.ret(Param1);
+}
+
 void TestImpl::TestByteString (
         std::string Param1,
         TestMessageHelper invocation) {

--- a/test/stub/teststubmain.cpp
+++ b/test/stub/teststubmain.cpp
@@ -122,6 +122,12 @@ void TestImpl::TestStringArray (
     invocation.ret(Param1);
 }
 
+void TestImpl::TestStructArray (
+        std::vector<std::tuple<guint32,Glib::ustring,gint32>> Param1,
+        TestMessageHelper invocation) {
+    invocation.ret(Param1);
+}
+
 void TestImpl::TestByteString (
         std::string Param1,
         TestMessageHelper invocation) {

--- a/test/stub/teststubmain.cpp
+++ b/test/stub/teststubmain.cpp
@@ -122,6 +122,12 @@ void TestImpl::TestStringArray (
     invocation.ret(Param1);
 }
 
+void TestImpl::TestStruct(
+        std::tuple<Glib::ustring,Glib::ustring> Param1,
+        TestMessageHelper invocation) {
+    invocation.ret(Param1);
+}
+
 void TestImpl::TestStructArray (
         std::vector<std::tuple<guint32,Glib::ustring,gint32>> Param1,
         TestMessageHelper invocation) {

--- a/test/stub/teststubmain.cpp
+++ b/test/stub/teststubmain.cpp
@@ -61,6 +61,24 @@ TestImpl::TestImpl() {
     m_PropReadWriteBooleanValue= true;
 }
 
+void TestImpl::TestStringVariantDict(std::map<Glib::ustring,Glib::VariantBase> Param1,
+                                     TestMessageHelper invocation)
+{
+    invocation.ret(Param1);
+}
+
+void TestImpl::TestStringStringDict(std::map<Glib::ustring,Glib::ustring> Param1,
+                                    TestMessageHelper invocation)
+{
+    invocation.ret(Param1);
+}
+
+void TestImpl::TestUintIntDict(std::map<guint32,gint32> Param1,
+                               TestMessageHelper invocation)
+{
+    invocation.ret(Param1);
+}
+
 void TestImpl::TestVariant(Glib::VariantBase Param1, TestMessageHelper invocation)
 {
     std::string value;

--- a/test/stub/teststubmain.h
+++ b/test/stub/teststubmain.h
@@ -25,6 +25,9 @@ public:
     void TestStringArray (
             std::vector<std::string>  Param1,
             TestMessageHelper invocation);
+    void TestStructArray (
+            std::vector<std::tuple<guint32,Glib::ustring,gint32>> Param1,
+            TestMessageHelper invocation);
     void TestByteString (
             std::string Param1,
             TestMessageHelper invocation);

--- a/test/stub/teststubmain.h
+++ b/test/stub/teststubmain.h
@@ -25,6 +25,9 @@ public:
     void TestStringArray (
             std::vector<std::string>  Param1,
             TestMessageHelper invocation);
+    void TestStruct(
+            std::tuple<Glib::ustring,Glib::ustring> Param1,
+            TestMessageHelper invocation);
     void TestStructArray (
             std::vector<std::tuple<guint32,Glib::ustring,gint32>> Param1,
             TestMessageHelper invocation);

--- a/test/stub/teststubmain.h
+++ b/test/stub/teststubmain.h
@@ -28,6 +28,9 @@ public:
     void TestStructArray (
             std::vector<std::tuple<guint32,Glib::ustring,gint32>> Param1,
             TestMessageHelper invocation);
+    void TestDictStructArray (
+            std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> Param1,
+            TestMessageHelper invocation);
     void TestByteString (
             std::string Param1,
             TestMessageHelper invocation);

--- a/test/stub/teststubmain.h
+++ b/test/stub/teststubmain.h
@@ -7,6 +7,15 @@ public:
     void TestVariant (
             Glib::VariantBase Param1,
             TestMessageHelper invocation);
+    void TestStringVariantDict(
+            std::map<Glib::ustring,Glib::VariantBase> Param1,
+            TestMessageHelper invocation) override;
+    void TestStringStringDict(
+            std::map<Glib::ustring,Glib::ustring> Param1,
+            TestMessageHelper invocation) override;
+    void TestUintIntDict(
+            std::map<guint32,gint32> Param1,
+            TestMessageHelper invocation) override;
     void TestByteStringArray (
             std::vector<std::string>  Param1,
             TestMessageHelper invocation);


### PR DESCRIPTION
Refactor the dbus type handling code to use a hierarchical class structure instead of a lot of "if"s.

Add support for D-Bus dictionaries and structures. I made sure that the code generated for other D-Bus types wouldn't change, so that existing apps won't break.