### PR TITLE
Upgrade: Upgrade python to v3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from setuptools import setup, find_packages
 setup(


### PR DESCRIPTION
By default it is using older python version.
So upgrading it to use v3.

Signed-off-by: Sapan Das <SKumarDas@luxoft.com>