### PR TITLE
codegen: Add --version

### DIFF
--- a/codegen_glibmm/__init__.py
+++ b/codegen_glibmm/__init__.py
@@ -21,6 +21,10 @@
 
 import os
 
+# Update this as the version changes
+version_info = (0, 1, 0)
+version = '.'.join(str(c) for c in version_info)
+
 builddir = os.environ.get('UNINSTALLED_GLIB_BUILDDIR')
 
 if builddir is not None:

--- a/codegen_glibmm/codegen_main.py
+++ b/codegen_glibmm/codegen_main.py
@@ -28,6 +28,7 @@ from . import utils
 from . import dbustypes
 from . import parser
 from . import codegen
+from . import version
 
 def find_arg(arg_list, arg_name):
     for a in arg_list:
@@ -54,7 +55,7 @@ def find_prop(iface, prop):
     return None
 
 def codegen_main():
-    arg_parser = optparse.OptionParser('%prog [options]')
+    arg_parser = optparse.OptionParser('%prog [options]', version=version)
     arg_parser.add_option('', '--interface-prefix', metavar='PREFIX', default='',
                             help='String to strip from D-Bus interface names for code and docs')
     arg_parser.add_option('', '--cpp-namespace', metavar='NAMESPACE', default='',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 from setuptools import setup, find_packages
+import codegen_glibmm
+
 setup(
     name = "gdbus-codegen.glibmm",
-    version = "0.1",
+    version = codegen_glibmm.version,
     packages = find_packages(),
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
With this commit, we also move to specifying the version of the code
generator in codegen_glibmm/__init__.py rather than setup.py. This makes
it easier for both the code generator itself and the setup code to know
of the version.