### PR TITLE
codegen: simplify handling of comments

### DIFF
--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -28,6 +28,12 @@ class Annotation:
         self.value = value
         self.annotations = []
 
+
+class Comment:
+    def __init__(self, lines):
+        self.lines = lines
+
+
 class Type:
     def __init__(self, signature, cpptype = ''):
         self.signature = signature

--- a/codegen_glibmm/templates/proxy.cpp.templ
+++ b/codegen_glibmm/templates/proxy.cpp.templ
@@ -8,6 +8,13 @@
 
 {% for interface in interfaces %}
 {% for method in interface.methods %}
+{% if method.doc_string %}
+/**
+{% for line in method.doc_string.lines %}
+ * {{ line }}
+{% endfor %}
+ */
+{% endif %}
 {% if not method is templated %}
 void {{ interface.cpp_namespace_name }}::{{ method.camel_name }}(
     {% for arg in method.in_args %}
@@ -73,6 +80,16 @@ void {{ interface.cpp_namespace_name }}::{{ prop.name }}_set({{ prop.cpptype_in 
 
 void {{ interface.cpp_namespace_name }}::{{ prop.name }}_set_finish(const Glib::RefPtr<Gio::AsyncResult>& res) {
 }
+
+{% endif %}
+{% endfor %}
+{% for signal in interface.signals if signal is supported_by_sigc %}
+{% if signal.doc_string %}
+/**
+{% for line in signal.doc_string.lines %}
+ * {{ line }}
+{% endfor %}
+ */
 
 {% endif %}
 {% endfor %}

--- a/tests/data/many-types/input.xml
+++ b/tests/data/many-types/input.xml
@@ -7,6 +7,12 @@
       <arg type="a{sv}" name="Param2" direction="out"></arg>
     </method>
 
+    <!--
+      TestStringStringDict:
+        @Param1: the dictionary of strings
+        @Param2: the output dictionary
+      This method tests sending and receiving a dictionary of strings
+    -->
     <method name="TestStringStringDict">
       <arg type="a{ss}" name="Param1" direction="in"></arg>
       <arg type="a{ss}" name="Param2" direction="out"></arg>
@@ -159,6 +165,11 @@
 
     <!-- Signals -->
 
+    <!--
+         TestSignalByteStringArray: emitted to test arrays of byte arrays.
+
+           @Param1: the array of arrays
+    -->
     <signal name="TestSignalByteStringArray">
         <arg type="aay" name="Param1"></arg>
     </signal>

--- a/tests/data/many-types/input_proxy.cpp
+++ b/tests/data/many-types/input_proxy.cpp
@@ -29,6 +29,12 @@ void org::gdbus::codegen::glibmm::Test::TestStringVariantDict_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+/**
+ * TestStringStringDict:
+ *   @Param1: the dictionary of strings
+ *   @Param2: the output dictionary
+ * This method tests sending and receiving a dictionary of strings
+ */
 void org::gdbus::codegen::glibmm::Test::TestStringStringDict(
     const std::map<Glib::ustring,Glib::ustring> & arg_Param1,
     const Gio::SlotAsyncReady &callback)
@@ -1540,6 +1546,11 @@ void org::gdbus::codegen::glibmm::Test::TestPropInternalReadWritePropertyChange_
 
 void org::gdbus::codegen::glibmm::Test::TestPropInternalReadWritePropertyChange_set_finish(const Glib::RefPtr<Gio::AsyncResult>& res) {
 }
+
+/**
+ * TestSignalByteStringArray: emitted to test arrays of byte arrays.
+ *   @Param1: the array of arrays
+ */
 
 void org::gdbus::codegen::glibmm::Test::handle_signal(const Glib::ustring& sender_name,
     const Glib::ustring& signal_name,

--- a/tests/data/many-types/input_stub.cpp
+++ b/tests/data/many-types/input_stub.cpp
@@ -7,6 +7,12 @@ static const char interfaceXml0[] = R"XML_DELIMITER(<!DOCTYPE node PUBLIC "-//fr
       <arg type="a{sv}" name="Param2" direction="out"></arg>
     </method>
 
+    <!--
+      TestStringStringDict:
+        @Param1: the dictionary of strings
+        @Param2: the output dictionary
+      This method tests sending and receiving a dictionary of strings
+    -->
     <method name="TestStringStringDict">
       <arg type="a{ss}" name="Param1" direction="in"></arg>
       <arg type="a{ss}" name="Param2" direction="out"></arg>
@@ -159,6 +165,11 @@ static const char interfaceXml0[] = R"XML_DELIMITER(<!DOCTYPE node PUBLIC "-//fr
 
     <!-- Signals -->
 
+    <!--
+         TestSignalByteStringArray: emitted to test arrays of byte arrays.
+
+           @Param1: the array of arrays
+    -->
     <signal name="TestSignalByteStringArray">
         <arg type="aay" name="Param1"></arg>
     </signal>


### PR DESCRIPTION
The previous implementation was not working at all: no documentation was
ever appearing on the generated code, as it was not in the templates.

With this commit we allow documenting methods and signals.