### PR TITLE
templates: don't leak GError when throwing exceptions

### DIFF
--- a/codegen_glibmm/templates/common.cpp.templ
+++ b/codegen_glibmm/templates/common.cpp.templ
@@ -19,7 +19,8 @@ static const GDBusErrorEntry error_entries[] = {
 static void throw_func(GError *gerror)
 {
     static const gchar prefix[] = "GDBus.Error:";
-    const gchar *message;
+    Glib::ustring message;
+    gint code = gerror->code;
 
     if (g_str_has_prefix(gerror->message, prefix)) {
         const char *colon = std::strstr(gerror->message + sizeof(prefix), ": ");
@@ -27,8 +28,9 @@ static void throw_func(GError *gerror)
     } else {
         message = gerror->message;
     }
+    g_error_free(gerror);
 
-    throw Error(gerror->code, message);
+    throw Error(code, message);
 }
 
 static Glib::Quark register_domain_with_dbus()

--- a/tests/data/error_namespace/input_common.cpp
+++ b/tests/data/error_namespace/input_common.cpp
@@ -15,7 +15,8 @@ static const GDBusErrorEntry error_entries[] = {
 static void throw_func(GError *gerror)
 {
     static const gchar prefix[] = "GDBus.Error:";
-    const gchar *message;
+    Glib::ustring message;
+    gint code = gerror->code;
 
     if (g_str_has_prefix(gerror->message, prefix)) {
         const char *colon = std::strstr(gerror->message + sizeof(prefix), ": ");
@@ -23,8 +24,9 @@ static void throw_func(GError *gerror)
     } else {
         message = gerror->message;
     }
+    g_error_free(gerror);
 
-    throw Error(gerror->code, message);
+    throw Error(code, message);
 }
 
 static Glib::Quark register_domain_with_dbus()

--- a/tests/data/simple/input_common.cpp
+++ b/tests/data/simple/input_common.cpp
@@ -16,7 +16,8 @@ static const GDBusErrorEntry error_entries[] = {
 static void throw_func(GError *gerror)
 {
     static const gchar prefix[] = "GDBus.Error:";
-    const gchar *message;
+    Glib::ustring message;
+    gint code = gerror->code;
 
     if (g_str_has_prefix(gerror->message, prefix)) {
         const char *colon = std::strstr(gerror->message + sizeof(prefix), ": ");
@@ -24,8 +25,9 @@ static void throw_func(GError *gerror)
     } else {
         message = gerror->message;
     }
+    g_error_free(gerror);
 
-    throw Error(gerror->code, message);
+    throw Error(code, message);
 }
 
 static Glib::Quark register_domain_with_dbus()


### PR DESCRIPTION
Fixes https://github.com/Pelagicore/gdbus-codegen-glibmm/issues/44