### PR TITLE
templates: Mark the proxy object as protected

### DIFF
--- a/codegen_glibmm/templates/proxy.h.templ
+++ b/codegen_glibmm/templates/proxy.h.templ
@@ -96,12 +96,14 @@ public:
                        const Glib::ustring &signal_name,
                        const Glib::VariantContainerBase &parameters);
 
+protected:
+    Glib::RefPtr<Gio::DBus::Proxy> m_proxy;
+
 private:
     {{ interface.cpp_class_name }}(Glib::RefPtr<Gio::DBus::Proxy> proxy): Glib::ObjectBase() {
         this->m_proxy = proxy;
         this->m_proxy->signal_signal().connect(sigc::mem_fun(this, &{{ interface.cpp_class_name }}::handle_signal));
     }
-    Glib::RefPtr<Gio::DBus::Proxy> m_proxy;
 };
 
 {% for namespace in namespaces|reverse %}

--- a/tests/data/many-types/input_proxy.h
+++ b/tests/data/many-types/input_proxy.h
@@ -458,12 +458,14 @@ public:
                        const Glib::ustring &signal_name,
                        const Glib::VariantContainerBase &parameters);
 
+protected:
+    Glib::RefPtr<Gio::DBus::Proxy> m_proxy;
+
 private:
     Test(Glib::RefPtr<Gio::DBus::Proxy> proxy): Glib::ObjectBase() {
         this->m_proxy = proxy;
         this->m_proxy->signal_signal().connect(sigc::mem_fun(this, &Test::handle_signal));
     }
-    Glib::RefPtr<Gio::DBus::Proxy> m_proxy;
 };
 
 }// glibmm

--- a/tests/data/simple/input_proxy.h
+++ b/tests/data/simple/input_proxy.h
@@ -42,12 +42,14 @@ public:
                        const Glib::ustring &signal_name,
                        const Glib::VariantContainerBase &parameters);
 
+protected:
+    Glib::RefPtr<Gio::DBus::Proxy> m_proxy;
+
 private:
     Test(Glib::RefPtr<Gio::DBus::Proxy> proxy): Glib::ObjectBase() {
         this->m_proxy = proxy;
         this->m_proxy->signal_signal().connect(sigc::mem_fun(this, &Test::handle_signal));
     }
-    Glib::RefPtr<Gio::DBus::Proxy> m_proxy;
 };
 
 }// glibmm


### PR DESCRIPTION
Let subclasses access it.