### PR TITLE
templates: Fix generator for ...MessageHelper classes

### DIFF
--- a/codegen_glibmm/templates/common.h.templ
+++ b/codegen_glibmm/templates/common.h.templ
@@ -100,10 +100,11 @@ public:
     }
 
 {% endfor %}
-{% endfor %}
 private:
     Glib::RefPtr<Gio::DBus::MethodInvocation> m_message;
 };
+
+{% endfor %}
 {% for interface in interfaces %}
 {% if interface.errors %}
 

--- a/codegen_glibmm/templates/common.h.templ
+++ b/codegen_glibmm/templates/common.h.templ
@@ -103,7 +103,9 @@ public:
 private:
     Glib::RefPtr<Gio::DBus::MethodInvocation> m_message;
 };
+{% if not loop.last %}
 
+{% endif %}
 {% endfor %}
 {% for interface in interfaces %}
 {% if interface.errors %}


### PR DESCRIPTION
All ...MessageHelper were created without private section. 
In addition they were not closed by the last '}' so class definition was incomplete.