### PR TITLE
templates: Add timeout argument to proxy D-Bus method calls

### DIFF
--- a/codegen_glibmm/templates/proxy.cpp.templ
+++ b/codegen_glibmm/templates/proxy.cpp.templ
@@ -22,7 +22,8 @@ void {{ class_name_with_namespace }}::{{ method.camel_name }}(
     {{ arg.cpptype_in }} arg_{{ arg.name }},
     {% endfor %}
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     {% if method.in_args|length > 0 %}
@@ -34,7 +35,7 @@ void {{ class_name_with_namespace }}::{{ method.camel_name }}(
     {%- endfor -%});
     {% endif %}
 
-    m_proxy->call("{{ method.name }}", callback, cancellable, base);
+    m_proxy->call("{{ method.name }}", callback, cancellable, base, timeout_msec);
 }
 
 {% endif %}

--- a/codegen_glibmm/templates/proxy.h.templ
+++ b/codegen_glibmm/templates/proxy.h.templ
@@ -37,7 +37,8 @@ public:
     {%- endfor -%}
     {% if method is templated %}
         const Gio::SlotAsyncReady &callback,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {})
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1)
     {
         Glib::VariantContainerBase base;
         {% if method.in_args|length > 0 %}
@@ -61,11 +62,12 @@ public:
         base = Glib::VariantContainerBase::create_tuple(params);
         {% endif %}
 
-        m_proxy->call( "{{ method.name }}", callback, cancellable, base);
+        m_proxy->call( "{{ method.name }}", callback, cancellable, base, timeout_msec);
     }
     {% else %}
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
     {% endif %}
 
     void {{ method.name }}_finish (

--- a/tests/data/many-types/input_proxy.cpp
+++ b/tests/data/many-types/input_proxy.cpp
@@ -9,13 +9,14 @@
 void org::gdbus::codegen::glibmm::Test::TestStringVariantDict(
     const std::map<Glib::ustring,Glib::VariantBase> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestStringVariantDict_pack(
         arg_Param1);
 
-    m_proxy->call("TestStringVariantDict", callback, cancellable, base);
+    m_proxy->call("TestStringVariantDict", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestStringVariantDict_finish(
@@ -39,13 +40,14 @@ void org::gdbus::codegen::glibmm::Test::TestStringVariantDict_finish(
 void org::gdbus::codegen::glibmm::Test::TestStringStringDict(
     const std::map<Glib::ustring,Glib::ustring> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestStringStringDict_pack(
         arg_Param1);
 
-    m_proxy->call("TestStringStringDict", callback, cancellable, base);
+    m_proxy->call("TestStringStringDict", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestStringStringDict_finish(
@@ -63,13 +65,14 @@ void org::gdbus::codegen::glibmm::Test::TestStringStringDict_finish(
 void org::gdbus::codegen::glibmm::Test::TestUintIntDict(
     const std::map<guint32,gint32> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestUintIntDict_pack(
         arg_Param1);
 
-    m_proxy->call("TestUintIntDict", callback, cancellable, base);
+    m_proxy->call("TestUintIntDict", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestUintIntDict_finish(
@@ -99,13 +102,14 @@ void org::gdbus::codegen::glibmm::Test::TestVariant_finish(
 void org::gdbus::codegen::glibmm::Test::TestByteStringArray(
     const std::vector<std::string> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestByteStringArray_pack(
         arg_Param1);
 
-    m_proxy->call("TestByteStringArray", callback, cancellable, base);
+    m_proxy->call("TestByteStringArray", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestByteStringArray_finish(
@@ -123,13 +127,14 @@ void org::gdbus::codegen::glibmm::Test::TestByteStringArray_finish(
 void org::gdbus::codegen::glibmm::Test::TestObjectPathArray(
     const std::vector<Glib::DBusObjectPathString> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestObjectPathArray_pack(
         arg_Param1);
 
-    m_proxy->call("TestObjectPathArray", callback, cancellable, base);
+    m_proxy->call("TestObjectPathArray", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestObjectPathArray_finish(
@@ -147,13 +152,14 @@ void org::gdbus::codegen::glibmm::Test::TestObjectPathArray_finish(
 void org::gdbus::codegen::glibmm::Test::TestStringArray(
     const std::vector<Glib::ustring> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestStringArray_pack(
         arg_Param1);
 
-    m_proxy->call("TestStringArray", callback, cancellable, base);
+    m_proxy->call("TestStringArray", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestStringArray_finish(
@@ -171,13 +177,14 @@ void org::gdbus::codegen::glibmm::Test::TestStringArray_finish(
 void org::gdbus::codegen::glibmm::Test::TestByteString(
     const std::string & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestByteString_pack(
         arg_Param1);
 
-    m_proxy->call("TestByteString", callback, cancellable, base);
+    m_proxy->call("TestByteString", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestByteString_finish(
@@ -195,13 +202,14 @@ void org::gdbus::codegen::glibmm::Test::TestByteString_finish(
 void org::gdbus::codegen::glibmm::Test::TestStruct(
     const std::tuple<Glib::ustring,Glib::ustring> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestStruct_pack(
         arg_Param1);
 
-    m_proxy->call("TestStruct", callback, cancellable, base);
+    m_proxy->call("TestStruct", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestStruct_finish(
@@ -219,13 +227,14 @@ void org::gdbus::codegen::glibmm::Test::TestStruct_finish(
 void org::gdbus::codegen::glibmm::Test::TestStructArray(
     const std::vector<std::tuple<guint32,Glib::ustring,gint32>> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestStructArray_pack(
         arg_Param1);
 
-    m_proxy->call("TestStructArray", callback, cancellable, base);
+    m_proxy->call("TestStructArray", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestStructArray_finish(
@@ -243,13 +252,14 @@ void org::gdbus::codegen::glibmm::Test::TestStructArray_finish(
 void org::gdbus::codegen::glibmm::Test::TestDictStructArray(
     const std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestDictStructArray_pack(
         arg_Param1);
 
-    m_proxy->call("TestDictStructArray", callback, cancellable, base);
+    m_proxy->call("TestDictStructArray", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestDictStructArray_finish(
@@ -267,13 +277,14 @@ void org::gdbus::codegen::glibmm::Test::TestDictStructArray_finish(
 void org::gdbus::codegen::glibmm::Test::TestSignature(
     const Glib::DBusSignatureString & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestSignature_pack(
         arg_Param1);
 
-    m_proxy->call("TestSignature", callback, cancellable, base);
+    m_proxy->call("TestSignature", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestSignature_finish(
@@ -291,13 +302,14 @@ void org::gdbus::codegen::glibmm::Test::TestSignature_finish(
 void org::gdbus::codegen::glibmm::Test::TestObjectPath(
     const Glib::DBusObjectPathString & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestObjectPath_pack(
         arg_Param1);
 
-    m_proxy->call("TestObjectPath", callback, cancellable, base);
+    m_proxy->call("TestObjectPath", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestObjectPath_finish(
@@ -315,13 +327,14 @@ void org::gdbus::codegen::glibmm::Test::TestObjectPath_finish(
 void org::gdbus::codegen::glibmm::Test::TestString(
     const Glib::ustring & arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestString_pack(
         arg_Param1);
 
-    m_proxy->call("TestString", callback, cancellable, base);
+    m_proxy->call("TestString", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestString_finish(
@@ -339,13 +352,14 @@ void org::gdbus::codegen::glibmm::Test::TestString_finish(
 void org::gdbus::codegen::glibmm::Test::TestDouble(
     double arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestDouble_pack(
         arg_Param1);
 
-    m_proxy->call("TestDouble", callback, cancellable, base);
+    m_proxy->call("TestDouble", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestDouble_finish(
@@ -363,13 +377,14 @@ void org::gdbus::codegen::glibmm::Test::TestDouble_finish(
 void org::gdbus::codegen::glibmm::Test::TestUInt64(
     guint64 arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestUInt64_pack(
         arg_Param1);
 
-    m_proxy->call("TestUInt64", callback, cancellable, base);
+    m_proxy->call("TestUInt64", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestUInt64_finish(
@@ -387,13 +402,14 @@ void org::gdbus::codegen::glibmm::Test::TestUInt64_finish(
 void org::gdbus::codegen::glibmm::Test::TestInt64(
     gint64 arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestInt64_pack(
         arg_Param1);
 
-    m_proxy->call("TestInt64", callback, cancellable, base);
+    m_proxy->call("TestInt64", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestInt64_finish(
@@ -411,13 +427,14 @@ void org::gdbus::codegen::glibmm::Test::TestInt64_finish(
 void org::gdbus::codegen::glibmm::Test::TestUInt(
     guint32 arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestUInt_pack(
         arg_Param1);
 
-    m_proxy->call("TestUInt", callback, cancellable, base);
+    m_proxy->call("TestUInt", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestUInt_finish(
@@ -435,13 +452,14 @@ void org::gdbus::codegen::glibmm::Test::TestUInt_finish(
 void org::gdbus::codegen::glibmm::Test::TestInt(
     gint32 arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestInt_pack(
         arg_Param1);
 
-    m_proxy->call("TestInt", callback, cancellable, base);
+    m_proxy->call("TestInt", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestInt_finish(
@@ -459,13 +477,14 @@ void org::gdbus::codegen::glibmm::Test::TestInt_finish(
 void org::gdbus::codegen::glibmm::Test::TestUInt16(
     guint16 arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestUInt16_pack(
         arg_Param1);
 
-    m_proxy->call("TestUInt16", callback, cancellable, base);
+    m_proxy->call("TestUInt16", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestUInt16_finish(
@@ -483,13 +502,14 @@ void org::gdbus::codegen::glibmm::Test::TestUInt16_finish(
 void org::gdbus::codegen::glibmm::Test::TestInt16(
     gint16 arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestInt16_pack(
         arg_Param1);
 
-    m_proxy->call("TestInt16", callback, cancellable, base);
+    m_proxy->call("TestInt16", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestInt16_finish(
@@ -507,13 +527,14 @@ void org::gdbus::codegen::glibmm::Test::TestInt16_finish(
 void org::gdbus::codegen::glibmm::Test::TestChar(
     guchar arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestChar_pack(
         arg_Param1);
 
-    m_proxy->call("TestChar", callback, cancellable, base);
+    m_proxy->call("TestChar", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestChar_finish(
@@ -531,13 +552,14 @@ void org::gdbus::codegen::glibmm::Test::TestChar_finish(
 void org::gdbus::codegen::glibmm::Test::TestBoolean(
     bool arg_Param1,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestBoolean_pack(
         arg_Param1);
 
-    m_proxy->call("TestBoolean", callback, cancellable, base);
+    m_proxy->call("TestBoolean", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestBoolean_finish(
@@ -570,7 +592,8 @@ void org::gdbus::codegen::glibmm::Test::TestAll(
     guchar arg_in_Param15,
     bool arg_in_Param16,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestAll_pack(
@@ -591,7 +614,7 @@ void org::gdbus::codegen::glibmm::Test::TestAll(
         arg_in_Param15,
         arg_in_Param16);
 
-    m_proxy->call("TestAll", callback, cancellable, base);
+    m_proxy->call("TestAll", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestAll_finish(
@@ -684,13 +707,14 @@ void org::gdbus::codegen::glibmm::Test::TestAll_finish(
 void org::gdbus::codegen::glibmm::Test::TestTriggerInternalPropertyChange(
     gint32 arg_NewPropertyValue,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestTriggerInternalPropertyChange_pack(
         arg_NewPropertyValue);
 
-    m_proxy->call("TestTriggerInternalPropertyChange", callback, cancellable, base);
+    m_proxy->call("TestTriggerInternalPropertyChange", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestTriggerInternalPropertyChange_finish(

--- a/tests/data/many-types/input_proxy.h
+++ b/tests/data/many-types/input_proxy.h
@@ -25,7 +25,8 @@ public:
     void TestStringVariantDict(
         const std::map<Glib::ustring,Glib::VariantBase> & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestStringVariantDict_finish (
         std::map<Glib::ustring,Glib::VariantBase> &Param2,
@@ -34,7 +35,8 @@ public:
     void TestStringStringDict(
         const std::map<Glib::ustring,Glib::ustring> & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestStringStringDict_finish (
         std::map<Glib::ustring,Glib::ustring> &Param2,
@@ -43,7 +45,8 @@ public:
     void TestUintIntDict(
         const std::map<guint32,gint32> & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestUintIntDict_finish (
         std::map<guint32,gint32> &Param2,
@@ -53,7 +56,8 @@ public:
     void TestVariant(
         T Param1,
         const Gio::SlotAsyncReady &callback,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {})
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1)
     {
         Glib::VariantContainerBase base;
         Glib::Variant<Glib::Variant<T>> variantValue =
@@ -61,7 +65,7 @@ public:
         Glib::VariantBase params = variantValue;
         base = Glib::VariantContainerBase::create_tuple(params);
 
-        m_proxy->call( "TestVariant", callback, cancellable, base);
+        m_proxy->call( "TestVariant", callback, cancellable, base, timeout_msec);
     }
 
     void TestVariant_finish (
@@ -71,7 +75,8 @@ public:
     void TestByteStringArray(
         const std::vector<std::string> & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestByteStringArray_finish (
         std::vector<std::string> &Param2,
@@ -80,7 +85,8 @@ public:
     void TestObjectPathArray(
         const std::vector<Glib::DBusObjectPathString> & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestObjectPathArray_finish (
         std::vector<Glib::DBusObjectPathString> &Param2,
@@ -89,7 +95,8 @@ public:
     void TestStringArray(
         const std::vector<Glib::ustring> & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestStringArray_finish (
         std::vector<Glib::ustring> &Param2,
@@ -98,7 +105,8 @@ public:
     void TestByteString(
         const std::string & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestByteString_finish (
         std::string &Param2,
@@ -107,7 +115,8 @@ public:
     void TestStruct(
         const std::tuple<Glib::ustring,Glib::ustring> & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestStruct_finish (
         std::tuple<Glib::ustring,Glib::ustring> &Param2,
@@ -116,7 +125,8 @@ public:
     void TestStructArray(
         const std::vector<std::tuple<guint32,Glib::ustring,gint32>> & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestStructArray_finish (
         std::vector<std::tuple<guint32,Glib::ustring,gint32>> &Param2,
@@ -125,7 +135,8 @@ public:
     void TestDictStructArray(
         const std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestDictStructArray_finish (
         std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> &Param2,
@@ -134,7 +145,8 @@ public:
     void TestSignature(
         const Glib::DBusSignatureString & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestSignature_finish (
         Glib::DBusSignatureString &Param2,
@@ -143,7 +155,8 @@ public:
     void TestObjectPath(
         const Glib::DBusObjectPathString & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestObjectPath_finish (
         Glib::DBusObjectPathString &Param2,
@@ -152,7 +165,8 @@ public:
     void TestString(
         const Glib::ustring & Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestString_finish (
         Glib::ustring &Param2,
@@ -161,7 +175,8 @@ public:
     void TestDouble(
         double Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestDouble_finish (
         double &Param2,
@@ -170,7 +185,8 @@ public:
     void TestUInt64(
         guint64 Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestUInt64_finish (
         guint64 &Param2,
@@ -179,7 +195,8 @@ public:
     void TestInt64(
         gint64 Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestInt64_finish (
         gint64 &Param2,
@@ -188,7 +205,8 @@ public:
     void TestUInt(
         guint32 Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestUInt_finish (
         guint32 &Param2,
@@ -197,7 +215,8 @@ public:
     void TestInt(
         gint32 Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestInt_finish (
         gint32 &Param2,
@@ -206,7 +225,8 @@ public:
     void TestUInt16(
         guint16 Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestUInt16_finish (
         guint16 &Param2,
@@ -215,7 +235,8 @@ public:
     void TestInt16(
         gint16 Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestInt16_finish (
         gint16 &Param2,
@@ -224,7 +245,8 @@ public:
     void TestChar(
         guchar Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestChar_finish (
         guchar &Param2,
@@ -233,7 +255,8 @@ public:
     void TestBoolean(
         bool Param1,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestBoolean_finish (
         bool &Param2,
@@ -257,7 +280,8 @@ public:
         guchar in_Param15,
         bool in_Param16,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestAll_finish (
         std::vector<std::string> &out_Param1,
@@ -281,7 +305,8 @@ public:
     void TestTriggerInternalPropertyChange(
         gint32 NewPropertyValue,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestTriggerInternalPropertyChange_finish (
         const Glib::RefPtr<Gio::AsyncResult> &res);

--- a/tests/data/simple/input_proxy.cpp
+++ b/tests/data/simple/input_proxy.cpp
@@ -10,14 +10,15 @@ void org::gdbus::codegen::glibmm::Test::TestCall(
     gint32 arg_Param1,
     const std::map<Glib::ustring,Glib::VariantBase> & arg_Param2,
     const Gio::SlotAsyncReady &callback,
-    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
 {
     Glib::VariantContainerBase base;
     base = TestTypeWrap::TestCall_pack(
         arg_Param1,
         arg_Param2);
 
-    m_proxy->call("TestCall", callback, cancellable, base);
+    m_proxy->call("TestCall", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestCall_finish(

--- a/tests/data/simple/input_proxy.h
+++ b/tests/data/simple/input_proxy.h
@@ -26,7 +26,8 @@ public:
         gint32 Param1,
         const std::map<Glib::ustring,Glib::VariantBase> & Param2,
         const Gio::SlotAsyncReady &slot,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestCall_finish (
         Glib::ustring &Param3,


### PR DESCRIPTION
Needed because some services do not return until a potentially very long operation has finished (e.g. waiting for input from user or configuring some hardware on the system).

Default to -1 which means use the GDBusProxy default (there is a property that is also set to -1 by  efault and means "use hard coded value of 25s in GDBusConnection").