### PR TITLE
Add synchronous versions of proxy creation, property set methods and method calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ int main(int argc, char **argv) {
 
 It can be compiled in a similar fashion as the previous example.
 
+There are synchronous versions available for method invocations, setting
+properties and creating a proxy that have a `_sync` suffix. These should only be
+used if it is acceptable to block the application for a very long time. For
+instance, the default method invocation timeout for a proxy is 25 seconds.
+Blocking for that amount of time is most likely not a good idea when writing
+e.g. a system daemon. The asynchronous version, that calls a callback when the
+D-Bus method returns, should be used instead.
+
 ## CMake integration
 Running the code generator from CMake can be done using the following snippet:
 

--- a/codegen_glibmm/codegen.py
+++ b/codegen_glibmm/codegen.py
@@ -152,12 +152,6 @@ class CodeGenerator:
         self.j2_env = Environment(loader=FileSystemLoader(THIS_DIR + "/templates/"),
                                   trim_blocks=True,
                                   lstrip_blocks=True)
-        def is_templated(method):
-            for a in method.in_args:
-                if a.templated:
-                    return True
-            return False
-        self.j2_env.tests['templated'] = is_templated
 
         def is_supported_by_sigc(signal):
             return len(signal.args) <= SIGNAL_MAX_PARAM

--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -157,7 +157,7 @@ class VariantType(Type):
 
     def cppvalue_get(self, outvar, idx, cpp_class_name):
         return 'GVariant *output;\n' +\
-                                'g_variant_get_child(wrapped.gobj(), 0, "v", &output);\n' + outvar + ' = Glib::VariantBase(output);'
+                                'g_variant_get_child(wrapped.gobj(), ' + idx + ', "v", &output);\n' + outvar + ' = Glib::VariantBase(output);'
 
 
 class ArrayType(Type):

--- a/codegen_glibmm/dbustypes.py
+++ b/codegen_glibmm/dbustypes.py
@@ -94,9 +94,6 @@ class Type:
         # Used to cast cpptype_in to variant_type when creating variants
         self.cpptype_to_dbus = ''
 
-        # Tells whether this type must be handled as a template
-        self.templated = False
-
     def __getattr__(self, name):
         if name == 'cpptype_in':
             return 'const ' + self.cpptype + ' &'
@@ -153,7 +150,6 @@ class StringType(Type):
 class VariantType(Type):
     def __init__(self):
         Type.__init__(self, 'v', 'Glib::VariantBase')
-        self.templated = True
 
     def cppvalue_get(self, outvar, idx, cpp_class_name):
         return 'GVariant *output;\n' +\

--- a/codegen_glibmm/templates/common.h.templ
+++ b/codegen_glibmm/templates/common.h.templ
@@ -38,7 +38,7 @@ public:
 
         return newStrv;
     }
-{% for method in interface.methods if not method is templated %}
+{% for method in interface.methods %}
 {% if method.in_args|length > 0 %}
 
     static Glib::VariantContainerBase {{ method.camel_name }}_pack(

--- a/codegen_glibmm/templates/proxy.cpp.templ
+++ b/codegen_glibmm/templates/proxy.cpp.templ
@@ -6,6 +6,8 @@
 
 #include "{{ proxy_h_name }}"
 
+#include <utility>
+
 {% for interface in interfaces %}
 {% set class_name_with_namespace = interface.cpp_namespace_name + '::' + interface.cpp_class_name %}
 {% for method in interface.methods %}
@@ -49,6 +51,52 @@ void {{ class_name_with_namespace }}::{{ method.camel_name }}_finish(
 
     {{ arg.cppvalue_get("out_" + arg.name, loop.index0|string, interface.cpp_class_name) | indent(1) }}
     {% endfor %}
+}
+
+{% if method.out_args|length == 0 %}
+void
+{% elif method.out_args|length == 1 %}
+{{ method.out_args[0].cpptype_out }}
+{% else %}
+std::tuple<{{ method.out_args|join(', ', attribute='cpptype_out') }}>
+{% endif %}
+{{ class_name_with_namespace }}::{{ method.camel_name }}_sync(
+    {% for arg in method.in_args %}
+    {{ arg.cpptype_in }} arg_{{ arg.name }},
+    {% endfor %}
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    {% if method.in_args|length > 0 %}
+    base = {{ interface.cpp_class_name }}TypeWrap::{{ method.camel_name }}_pack(
+    {%- set comma = joiner(',') -%}
+    {%- for arg in method.in_args -%}
+        {{ comma() }}
+        arg_{{ arg.name }}
+    {%- endfor -%});
+    {% endif %}
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("{{ method.name }}", cancellable, base, timeout_msec);
+
+{% if method.out_args|length == 1 %}
+    {% set arg = method.out_args[0] %}
+    {{ arg.cpptype_out }} out_{{ arg.name }};
+    {{ arg.cppvalue_get("out_" + arg.name, "0", interface.cpp_class_name) | indent(1) }}
+    return out_{{ arg.name }};
+{% elif method.out_args|length > 1 %}
+    {% for arg in method.out_args %}
+    {{ arg.cpptype_out }} out_{{ arg.name }};
+    {{ arg.cppvalue_get("out_" + arg.name, loop.index0|string, interface.cpp_class_name) | indent(1) }}
+
+    {% endfor %}
+    return std::make_tuple(
+    {% for arg in method.out_args %}
+        std::move(out_{{ arg.name }}){{ "," if not loop.last }}
+    {% endfor %}
+    );
+{% endif %}
 }
 
 {% endfor %}

--- a/codegen_glibmm/templates/proxy.cpp.templ
+++ b/codegen_glibmm/templates/proxy.cpp.templ
@@ -172,4 +172,24 @@ Glib::RefPtr<{{ class_name_with_namespace }}> {{ class_name_with_namespace }}::c
         new {{ class_name_with_namespace }}(proxy);
     return Glib::RefPtr<{{ class_name_with_namespace }}>(p);
 }
+
+Glib::RefPtr<{{ class_name_with_namespace }}> {{ class_name_with_namespace }}::createForBus_sync(
+    Gio::DBus::BusType busType,
+    Gio::DBus::ProxyFlags proxyFlags,
+    const std::string &name,
+    const std::string &objectPath,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+{
+    Glib::RefPtr<Gio::DBus::Proxy> proxy =
+        Gio::DBus::Proxy::create_for_bus_sync(busType,
+            name,
+            objectPath,
+            "{{ interface.name }}",
+            cancellable,
+            Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+            proxyFlags);
+    {{ class_name_with_namespace }} *p =
+        new {{ class_name_with_namespace }}(proxy);
+    return Glib::RefPtr<{{ class_name_with_namespace }}>(p);
+}
 {%- endfor %}

--- a/codegen_glibmm/templates/proxy.cpp.templ
+++ b/codegen_glibmm/templates/proxy.cpp.templ
@@ -16,7 +16,6 @@
 {% endfor %}
  */
 {% endif %}
-{% if not method is templated %}
 void {{ class_name_with_namespace }}::{{ method.camel_name }}(
     {% for arg in method.in_args %}
     {{ arg.cpptype_in }} arg_{{ arg.name }},
@@ -38,7 +37,6 @@ void {{ class_name_with_namespace }}::{{ method.camel_name }}(
     m_proxy->call("{{ method.name }}", callback, cancellable, base, timeout_msec);
 }
 
-{% endif %}
 void {{ class_name_with_namespace }}::{{ method.camel_name }}_finish(
     {% for arg in method.out_args %}
     {{ arg.cpptype_out }} &out_{{ arg.name }},

--- a/codegen_glibmm/templates/proxy.cpp.templ
+++ b/codegen_glibmm/templates/proxy.cpp.templ
@@ -82,6 +82,15 @@ void {{ class_name_with_namespace }}::{{ prop.name }}_set({{ prop.cpptype_in }} 
 void {{ class_name_with_namespace }}::{{ prop.name }}_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void {{ class_name_with_namespace }}::{{ prop.name }}_set_sync({{ prop.cpptype_in }} value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("{{ interface.name }}"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("{{ prop.name }}"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<{{ prop.variant_type }}>::create({{ prop.cpptype_to_dbus }}(value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 {% endif %}
 {% endfor %}
 {% for signal in interface.signals if signal is supported_by_sigc %}

--- a/codegen_glibmm/templates/proxy.h.templ
+++ b/codegen_glibmm/templates/proxy.h.templ
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <tuple>
 #include <vector>
 #include <glibmm.h>
 #include <giomm.h>
@@ -45,6 +46,20 @@ public:
         {{ arg.cpptype_out }} &{{ arg.name }},
         {% endfor %}
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    {% if method.out_args|length == 0 %}
+    void
+    {% elif method.out_args|length == 1 %}
+    {{ method.out_args[0].cpptype_out }}
+    {% else %}
+    std::tuple<{{ method.out_args|join(', ', attribute='cpptype_out') }}>
+    {% endif %}
+    {{ method.name }}_sync(
+    {% for arg in method.in_args %}
+        {{ arg.cpptype_in }} {{ arg.name }},
+    {%- endfor -%}
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
 {% endfor %}
 {% for prop in interface.properties %}

--- a/codegen_glibmm/templates/proxy.h.templ
+++ b/codegen_glibmm/templates/proxy.h.templ
@@ -54,6 +54,7 @@ public:
     {% if prop.writable %}
     void {{ prop.name }}_set({{ prop.cpptype_in }}, const Gio::SlotAsyncReady &);
     void {{ prop.name }}_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void {{ prop.name }}_set_sync({{ prop.cpptype_in }});
     {% endif %}
     sigc::signal<void> &{{ prop.name }}_changed() {
         return m_{{ prop.name }}_changed;

--- a/codegen_glibmm/templates/proxy.h.templ
+++ b/codegen_glibmm/templates/proxy.h.templ
@@ -22,6 +22,13 @@ public:
 
     static Glib::RefPtr<{{ interface.cpp_class_name }}> createForBusFinish (Glib::RefPtr<Gio::AsyncResult> result);
 
+    static Glib::RefPtr<{{ interface.cpp_class_name }}> createForBus_sync(
+        Gio::DBus::BusType busType,
+        Gio::DBus::ProxyFlags proxyFlags,
+        const std::string &name,
+        const std::string &objectPath,
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+
     Glib::RefPtr<Gio::DBus::Proxy> dbusProxy() const { return m_proxy; }
 
 {% for method in interface.methods %}

--- a/codegen_glibmm/templates/proxy.h.templ
+++ b/codegen_glibmm/templates/proxy.h.templ
@@ -25,51 +25,13 @@ public:
     Glib::RefPtr<Gio::DBus::Proxy> dbusProxy() const { return m_proxy; }
 
 {% for method in interface.methods %}
-    {% if method is templated %}
-    template <typename T>
-    {% endif %}
     void {{ method.name }}(
     {% for arg in method.in_args %}
-        {% if arg.templated %}
-        T {{ arg.name }},
-        {% else %}
         {{ arg.cpptype_in }} {{ arg.name }},
-        {% endif %}
-    {%- endfor -%}
-    {% if method is templated %}
-        const Gio::SlotAsyncReady &callback,
-        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
-        int timeout_msec = -1)
-    {
-        Glib::VariantContainerBase base;
-        {% if method.in_args|length > 0 %}
-        {% if method.in_args|length > 1 %}
-        std::vector<Glib::VariantBase> params;
-        {% for arg in method.in_args %}
-        {% if arg.templated %}
-        Glib::Variant<Glib::Variant<T>> {{ arg.name }}_variantValue =
-            Glib::Variant<Glib::Variant<T>>::create(Glib::Variant<T>::create({{ arg.name }}));
-        params.push_back({{ arg.name }}_variantValue);
-        {% else %}
-        {{ arg.cppvalue_send(arg.name + "_param", arg.name, interface.cpp_class_name) }}
-        params.push_back({{ arg.name }}_param);
-        {% endif %}
-        {%- endfor -%}
-        {% else %}
-        Glib::Variant<Glib::Variant<T>> variantValue =
-            Glib::Variant<Glib::Variant<T>>::create(Glib::Variant<T>::create({{ method.in_args[0].name }}));
-        Glib::VariantBase params = variantValue;
-        {% endif %}
-        base = Glib::VariantContainerBase::create_tuple(params);
-        {% endif %}
-
-        m_proxy->call( "{{ method.name }}", callback, cancellable, base, timeout_msec);
-    }
-    {% else %}
+    {% endfor %}
         const Gio::SlotAsyncReady &slot,
         const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
         int timeout_msec = -1);
-    {% endif %}
 
     void {{ method.name }}_finish (
         {% for arg in method.out_args %}

--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -80,20 +80,10 @@ void {{ class_name_with_namespace }}::on_method_call(
 
 {% for method in interface.methods %}
     if (method_name.compare("{{ method.name }}") == 0) {
-        {% if method is templated %}
-        Glib::VariantContainerBase containerBase = parameters;
-        {% endif %}
     {% for arg in method.in_args %}
-        {% if arg.templated %}
-        GVariant *output{{ loop.index0 }};
-        g_variant_get_child(containerBase.gobj(), {{ loop.index0 }}, "v", &output{{ loop.index0 }});
-        Glib::VariantBase p_{{ arg.name }} =
-            Glib::VariantBase(output{{ loop.index0 }});
-        {% else %}
         Glib::Variant<{{ arg.variant_type }}> base_{{ arg.name }};
         parameters.get_child(base_{{ arg.name }}, {{ loop.index0 }});
         {{ arg.variant_type }} p_{{ arg.name }} = base_{{ arg.name }}.get();
-        {% endif %}
 
     {% endfor %}
         {{ method.name }}(

--- a/tests/data/many-types/input.xml
+++ b/tests/data/many-types/input.xml
@@ -28,6 +28,13 @@
        <arg type="v" name="Param2" direction="out"></arg>
     </method>
 
+    <method name="TestVariant2">
+       <arg type="s" name="Param1" direction="in"></arg>
+       <arg type="v" name="Param2" direction="in"></arg>
+       <arg type="s" name="Param3" direction="out"></arg>
+       <arg type="v" name="Param4" direction="out"></arg>
+    </method>
+
     <method name="TestByteStringArray">
         <arg type="aay" name="Param1" direction="in"></arg>
         <arg type="aay" name="Param2" direction="out"></arg>

--- a/tests/data/many-types/input_common.h
+++ b/tests/data/many-types/input_common.h
@@ -62,6 +62,30 @@ public:
         return Glib::VariantContainerBase::create_tuple(params);
     }
 
+    static Glib::VariantContainerBase TestVariant_pack(
+        const Glib::VariantBase & arg_Param1) {
+        Glib::VariantContainerBase base;
+        Glib::Variant<Glib::VariantBase> params =
+            Glib::Variant<Glib::VariantBase>::create(arg_Param1);
+        return Glib::VariantContainerBase::create_tuple(params);
+    }
+
+    static Glib::VariantContainerBase TestVariant2_pack(
+        const Glib::ustring & arg_Param1,
+        const Glib::VariantBase & arg_Param2) {
+        Glib::VariantContainerBase base;
+        std::vector<Glib::VariantBase> params;
+
+        Glib::Variant<Glib::ustring> Param1_param =
+            Glib::Variant<Glib::ustring>::create(arg_Param1);
+        params.push_back(Param1_param);
+
+        Glib::Variant<Glib::VariantBase> Param2_param =
+            Glib::Variant<Glib::VariantBase>::create(arg_Param2);
+        params.push_back(Param2_param);
+        return Glib::VariantContainerBase::create_tuple(params);
+    }
+
     static Glib::VariantContainerBase TestByteStringArray_pack(
         const std::vector<std::string> & arg_Param1) {
         Glib::VariantContainerBase base;

--- a/tests/data/many-types/input_proxy.cpp
+++ b/tests/data/many-types/input_proxy.cpp
@@ -87,6 +87,19 @@ void org::gdbus::codegen::glibmm::Test::TestUintIntDict_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+void org::gdbus::codegen::glibmm::Test::TestVariant(
+    const Glib::VariantBase & arg_Param1,
+    const Gio::SlotAsyncReady &callback,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestVariant_pack(
+        arg_Param1);
+
+    m_proxy->call("TestVariant", callback, cancellable, base, timeout_msec);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestVariant_finish(
     Glib::VariantBase &out_Param2,
     const Glib::RefPtr<Gio::AsyncResult> &result)
@@ -97,6 +110,21 @@ void org::gdbus::codegen::glibmm::Test::TestVariant_finish(
     GVariant *output;
     g_variant_get_child(wrapped.gobj(), 0, "v", &output);
     out_Param2 = Glib::VariantBase(output);
+}
+
+void org::gdbus::codegen::glibmm::Test::TestVariant2(
+    const Glib::ustring & arg_Param1,
+    const Glib::VariantBase & arg_Param2,
+    const Gio::SlotAsyncReady &callback,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestVariant2_pack(
+        arg_Param1,
+        arg_Param2);
+
+    m_proxy->call("TestVariant2", callback, cancellable, base, timeout_msec);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestVariant2_finish(

--- a/tests/data/many-types/input_proxy.cpp
+++ b/tests/data/many-types/input_proxy.cpp
@@ -99,6 +99,23 @@ void org::gdbus::codegen::glibmm::Test::TestVariant_finish(
     out_Param2 = Glib::VariantBase(output);
 }
 
+void org::gdbus::codegen::glibmm::Test::TestVariant2_finish(
+    Glib::ustring &out_Param3,
+    Glib::VariantBase &out_Param4,
+    const Glib::RefPtr<Gio::AsyncResult> &result)
+{
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_finish(result);
+
+    Glib::Variant<Glib::ustring> out_Param3_v;
+    wrapped.get_child(out_Param3_v, 0);
+    out_Param3 = out_Param3_v.get();
+
+    GVariant *output;
+    g_variant_get_child(wrapped.gobj(), 1, "v", &output);
+    out_Param4 = Glib::VariantBase(output);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestByteStringArray(
     const std::vector<std::string> & arg_Param1,
     const Gio::SlotAsyncReady &callback,

--- a/tests/data/many-types/input_proxy.cpp
+++ b/tests/data/many-types/input_proxy.cpp
@@ -1003,6 +1003,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteByteStringArray_set(const s
 void org::gdbus::codegen::glibmm::Test::TestPropWriteByteStringArray_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropWriteByteStringArray_set_sync(const std::vector<std::string> & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteByteStringArray"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<std::vector<std::string>>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestPropWriteObjectPathArray_set(const std::vector<Glib::DBusObjectPathString> & value, const Gio::SlotAsyncReady &cb)
 {
     std::vector<Glib::VariantBase> paramsVec;
@@ -1014,6 +1023,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteObjectPathArray_set(const s
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteObjectPathArray_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropWriteObjectPathArray_set_sync(const std::vector<Glib::DBusObjectPathString> & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteObjectPathArray"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<std::vector<Glib::DBusObjectPathString>>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteStringArray_set(const std::vector<Glib::ustring> & value, const Gio::SlotAsyncReady &cb)
@@ -1029,6 +1047,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteStringArray_set(const std::
 void org::gdbus::codegen::glibmm::Test::TestPropWriteStringArray_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropWriteStringArray_set_sync(const std::vector<Glib::ustring> & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteStringArray"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<std::vector<Glib::ustring>>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestPropWriteByteString_set(const std::string & value, const Gio::SlotAsyncReady &cb)
 {
     std::vector<Glib::VariantBase> paramsVec;
@@ -1040,6 +1067,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteByteString_set(const std::s
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteByteString_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropWriteByteString_set_sync(const std::string & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteByteString"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<std::string>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteSignature_set(const Glib::DBusSignatureString & value, const Gio::SlotAsyncReady &cb)
@@ -1055,6 +1091,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteSignature_set(const Glib::D
 void org::gdbus::codegen::glibmm::Test::TestPropWriteSignature_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropWriteSignature_set_sync(const Glib::DBusSignatureString & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteSignature"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<Glib::DBusSignatureString>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestPropWriteObjectPath_set(const Glib::DBusObjectPathString & value, const Gio::SlotAsyncReady &cb)
 {
     std::vector<Glib::VariantBase> paramsVec;
@@ -1066,6 +1111,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteObjectPath_set(const Glib::
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteObjectPath_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropWriteObjectPath_set_sync(const Glib::DBusObjectPathString & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteObjectPath"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<Glib::DBusObjectPathString>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteString_set(const Glib::ustring & value, const Gio::SlotAsyncReady &cb)
@@ -1081,6 +1135,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteString_set(const Glib::ustr
 void org::gdbus::codegen::glibmm::Test::TestPropWriteString_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropWriteString_set_sync(const Glib::ustring & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteString"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<Glib::ustring>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestPropWriteDouble_set(double value, const Gio::SlotAsyncReady &cb)
 {
     std::vector<Glib::VariantBase> paramsVec;
@@ -1092,6 +1155,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteDouble_set(double value, co
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteDouble_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropWriteDouble_set_sync(double value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteDouble"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<double>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt64_set(guint64 value, const Gio::SlotAsyncReady &cb)
@@ -1107,6 +1179,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt64_set(guint64 value, c
 void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt64_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt64_set_sync(guint64 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteUInt64"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<guint64>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestPropWriteInt64_set(gint64 value, const Gio::SlotAsyncReady &cb)
 {
     std::vector<Glib::VariantBase> paramsVec;
@@ -1118,6 +1199,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteInt64_set(gint64 value, con
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteInt64_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropWriteInt64_set_sync(gint64 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteInt64"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<gint64>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt_set(guint32 value, const Gio::SlotAsyncReady &cb)
@@ -1133,6 +1223,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt_set(guint32 value, con
 void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt_set_sync(guint32 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteUInt"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<guint32>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestPropWriteInt_set(gint32 value, const Gio::SlotAsyncReady &cb)
 {
     std::vector<Glib::VariantBase> paramsVec;
@@ -1144,6 +1243,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteInt_set(gint32 value, const
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteInt_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropWriteInt_set_sync(gint32 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteInt"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<gint32>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt16_set(guint16 value, const Gio::SlotAsyncReady &cb)
@@ -1159,6 +1267,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt16_set(guint16 value, c
 void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt16_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropWriteUInt16_set_sync(guint16 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteUInt16"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<guint16>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestPropWriteInt16_set(gint16 value, const Gio::SlotAsyncReady &cb)
 {
     std::vector<Glib::VariantBase> paramsVec;
@@ -1170,6 +1287,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteInt16_set(gint16 value, con
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteInt16_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropWriteInt16_set_sync(gint16 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteInt16"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<gint16>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteChar_set(guchar value, const Gio::SlotAsyncReady &cb)
@@ -1185,6 +1311,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteChar_set(guchar value, cons
 void org::gdbus::codegen::glibmm::Test::TestPropWriteChar_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropWriteChar_set_sync(guchar value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteChar"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<guchar>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 void org::gdbus::codegen::glibmm::Test::TestPropWriteBoolean_set(bool value, const Gio::SlotAsyncReady &cb)
 {
     std::vector<Glib::VariantBase> paramsVec;
@@ -1196,6 +1331,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropWriteBoolean_set(bool value, con
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropWriteBoolean_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropWriteBoolean_set_sync(bool value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropWriteBoolean"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<bool>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 std::vector<std::string> org::gdbus::codegen::glibmm::Test::TestPropReadWriteByteStringArray_get()
@@ -1224,6 +1368,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteByteStringArray_set(con
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteByteStringArray_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteByteStringArray_set_sync(const std::vector<std::string> & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteByteStringArray"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<std::vector<std::string>>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 std::vector<Glib::DBusObjectPathString> org::gdbus::codegen::glibmm::Test::TestPropReadWriteObjectPathArray_get()
 {
     std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
@@ -1248,6 +1401,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteObjectPathArray_set(con
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteObjectPathArray_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteObjectPathArray_set_sync(const std::vector<Glib::DBusObjectPathString> & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteObjectPathArray"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<std::vector<Glib::DBusObjectPathString>>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 std::vector<Glib::ustring> org::gdbus::codegen::glibmm::Test::TestPropReadWriteStringArray_get()
@@ -1276,6 +1438,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteStringArray_set(const s
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteStringArray_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteStringArray_set_sync(const std::vector<Glib::ustring> & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteStringArray"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<std::vector<Glib::ustring>>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 std::string org::gdbus::codegen::glibmm::Test::TestPropReadWriteByteString_get()
 {
     std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
@@ -1300,6 +1471,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteByteString_set(const st
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteByteString_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteByteString_set_sync(const std::string & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteByteString"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<std::string>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 Glib::DBusSignatureString org::gdbus::codegen::glibmm::Test::TestPropReadWriteSignature_get()
@@ -1328,6 +1508,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteSignature_set(const Gli
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteSignature_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteSignature_set_sync(const Glib::DBusSignatureString & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteSignature"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<Glib::DBusSignatureString>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 Glib::DBusObjectPathString org::gdbus::codegen::glibmm::Test::TestPropReadWriteObjectPath_get()
 {
     std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
@@ -1352,6 +1541,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteObjectPath_set(const Gl
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteObjectPath_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteObjectPath_set_sync(const Glib::DBusObjectPathString & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteObjectPath"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<Glib::DBusObjectPathString>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 Glib::ustring org::gdbus::codegen::glibmm::Test::TestPropReadWriteString_get()
@@ -1380,6 +1578,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteString_set(const Glib::
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteString_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteString_set_sync(const Glib::ustring & value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteString"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<Glib::ustring>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 double org::gdbus::codegen::glibmm::Test::TestPropReadWriteDouble_get()
 {
     std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
@@ -1404,6 +1611,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteDouble_set(double value
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteDouble_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteDouble_set_sync(double value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteDouble"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<double>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 guint64 org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt64_get()
@@ -1432,6 +1648,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt64_set(guint64 valu
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt64_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt64_set_sync(guint64 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteUInt64"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<guint64>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 gint64 org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt64_get()
 {
     std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
@@ -1456,6 +1681,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt64_set(gint64 value,
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt64_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt64_set_sync(gint64 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteInt64"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<gint64>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 guint32 org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt_get()
@@ -1484,6 +1718,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt_set(guint32 value,
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt_set_sync(guint32 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteUInt"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<guint32>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 gint32 org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt_get()
 {
     std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
@@ -1508,6 +1751,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt_set(gint32 value, c
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt_set_sync(gint32 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteInt"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<gint32>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 guint16 org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt16_get()
@@ -1536,6 +1788,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt16_set(guint16 valu
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt16_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteUInt16_set_sync(guint16 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteUInt16"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<guint16>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 gint16 org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt16_get()
 {
     std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
@@ -1560,6 +1821,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt16_set(gint16 value,
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt16_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteInt16_set_sync(gint16 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteInt16"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<gint16>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 guchar org::gdbus::codegen::glibmm::Test::TestPropReadWriteChar_get()
@@ -1588,6 +1858,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteChar_set(guchar value, 
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteChar_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteChar_set_sync(guchar value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteChar"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<guchar>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 bool org::gdbus::codegen::glibmm::Test::TestPropReadWriteBoolean_get()
 {
     std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
@@ -1614,6 +1893,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropReadWriteBoolean_set(bool value,
 void org::gdbus::codegen::glibmm::Test::TestPropReadWriteBoolean_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
 }
 
+void org::gdbus::codegen::glibmm::Test::TestPropReadWriteBoolean_set_sync(bool value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropReadWriteBoolean"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<bool>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
+}
+
 gint32 org::gdbus::codegen::glibmm::Test::TestPropInternalReadWritePropertyChange_get()
 {
     std::vector<Glib::ustring> props = m_proxy->get_cached_property_names();
@@ -1638,6 +1926,15 @@ void org::gdbus::codegen::glibmm::Test::TestPropInternalReadWritePropertyChange_
 }
 
 void org::gdbus::codegen::glibmm::Test::TestPropInternalReadWritePropertyChange_set_finish(const Glib::RefPtr<Gio::AsyncResult>&/* res */) {
+}
+
+void org::gdbus::codegen::glibmm::Test::TestPropInternalReadWritePropertyChange_set_sync(gint32 value) {
+    std::vector<Glib::VariantBase> paramsVec;
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("org.gdbus.codegen.glibmm.Test"));
+    paramsVec.push_back(Glib::Variant<Glib::ustring>::create("TestPropInternalReadWritePropertyChange"));
+    paramsVec.push_back(Glib::Variant<Glib::VariantBase>::create(Glib::Variant<gint32>::create((value))));
+    Glib::VariantContainerBase params = Glib::VariantContainerBase::create_tuple(paramsVec);
+    m_proxy->call_sync("org.freedesktop.DBus.Properties.Set", params);
 }
 
 /**

--- a/tests/data/many-types/input_proxy.cpp
+++ b/tests/data/many-types/input_proxy.cpp
@@ -1943,3 +1943,23 @@ Glib::RefPtr<org::gdbus::codegen::glibmm::Test> org::gdbus::codegen::glibmm::Tes
         new org::gdbus::codegen::glibmm::Test(proxy);
     return Glib::RefPtr<org::gdbus::codegen::glibmm::Test>(p);
 }
+
+Glib::RefPtr<org::gdbus::codegen::glibmm::Test> org::gdbus::codegen::glibmm::Test::createForBus_sync(
+    Gio::DBus::BusType busType,
+    Gio::DBus::ProxyFlags proxyFlags,
+    const std::string &name,
+    const std::string &objectPath,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+{
+    Glib::RefPtr<Gio::DBus::Proxy> proxy =
+        Gio::DBus::Proxy::create_for_bus_sync(busType,
+            name,
+            objectPath,
+            "org.gdbus.codegen.glibmm.Test",
+            cancellable,
+            Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+            proxyFlags);
+    org::gdbus::codegen::glibmm::Test *p =
+        new org::gdbus::codegen::glibmm::Test(proxy);
+    return Glib::RefPtr<org::gdbus::codegen::glibmm::Test>(p);
+}

--- a/tests/data/many-types/input_proxy.cpp
+++ b/tests/data/many-types/input_proxy.cpp
@@ -6,6 +6,8 @@
 
 #include "OUTPUT_DIR/input_proxy.h"
 
+#include <utility>
+
 void org::gdbus::codegen::glibmm::Test::TestStringVariantDict(
     const std::map<Glib::ustring,Glib::VariantBase> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -29,6 +31,26 @@ void org::gdbus::codegen::glibmm::Test::TestStringVariantDict_finish(
     Glib::Variant<std::map<Glib::ustring,Glib::VariantBase>> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+std::map<Glib::ustring,Glib::VariantBase>
+org::gdbus::codegen::glibmm::Test::TestStringVariantDict_sync(
+    const std::map<Glib::ustring,Glib::VariantBase> & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestStringVariantDict_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestStringVariantDict", cancellable, base, timeout_msec);
+
+    std::map<Glib::ustring,Glib::VariantBase> out_Param2;
+    Glib::Variant<std::map<Glib::ustring,Glib::VariantBase>> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 /**
@@ -62,6 +84,26 @@ void org::gdbus::codegen::glibmm::Test::TestStringStringDict_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+std::map<Glib::ustring,Glib::ustring>
+org::gdbus::codegen::glibmm::Test::TestStringStringDict_sync(
+    const std::map<Glib::ustring,Glib::ustring> & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestStringStringDict_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestStringStringDict", cancellable, base, timeout_msec);
+
+    std::map<Glib::ustring,Glib::ustring> out_Param2;
+    Glib::Variant<std::map<Glib::ustring,Glib::ustring>> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestUintIntDict(
     const std::map<guint32,gint32> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -87,6 +129,26 @@ void org::gdbus::codegen::glibmm::Test::TestUintIntDict_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+std::map<guint32,gint32>
+org::gdbus::codegen::glibmm::Test::TestUintIntDict_sync(
+    const std::map<guint32,gint32> & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestUintIntDict_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestUintIntDict", cancellable, base, timeout_msec);
+
+    std::map<guint32,gint32> out_Param2;
+    Glib::Variant<std::map<guint32,gint32>> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestVariant(
     const Glib::VariantBase & arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -110,6 +172,26 @@ void org::gdbus::codegen::glibmm::Test::TestVariant_finish(
     GVariant *output;
     g_variant_get_child(wrapped.gobj(), 0, "v", &output);
     out_Param2 = Glib::VariantBase(output);
+}
+
+Glib::VariantBase
+org::gdbus::codegen::glibmm::Test::TestVariant_sync(
+    const Glib::VariantBase & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestVariant_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestVariant", cancellable, base, timeout_msec);
+
+    Glib::VariantBase out_Param2;
+    GVariant *output;
+    g_variant_get_child(wrapped.gobj(), 0, "v", &output);
+    out_Param2 = Glib::VariantBase(output);
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestVariant2(
@@ -144,6 +226,37 @@ void org::gdbus::codegen::glibmm::Test::TestVariant2_finish(
     out_Param4 = Glib::VariantBase(output);
 }
 
+std::tuple<Glib::ustring, Glib::VariantBase>
+org::gdbus::codegen::glibmm::Test::TestVariant2_sync(
+    const Glib::ustring & arg_Param1,
+    const Glib::VariantBase & arg_Param2,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestVariant2_pack(
+        arg_Param1,
+        arg_Param2);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestVariant2", cancellable, base, timeout_msec);
+
+    Glib::ustring out_Param3;
+    Glib::Variant<Glib::ustring> out_Param3_v;
+    wrapped.get_child(out_Param3_v, 0);
+    out_Param3 = out_Param3_v.get();
+
+    Glib::VariantBase out_Param4;
+    GVariant *output;
+    g_variant_get_child(wrapped.gobj(), 1, "v", &output);
+    out_Param4 = Glib::VariantBase(output);
+
+    return std::make_tuple(
+        std::move(out_Param3),
+        std::move(out_Param4)
+    );
+}
+
 void org::gdbus::codegen::glibmm::Test::TestByteStringArray(
     const std::vector<std::string> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -167,6 +280,26 @@ void org::gdbus::codegen::glibmm::Test::TestByteStringArray_finish(
     Glib::Variant<std::vector<std::string>> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+std::vector<std::string>
+org::gdbus::codegen::glibmm::Test::TestByteStringArray_sync(
+    const std::vector<std::string> & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestByteStringArray_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestByteStringArray", cancellable, base, timeout_msec);
+
+    std::vector<std::string> out_Param2;
+    Glib::Variant<std::vector<std::string>> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestObjectPathArray(
@@ -194,6 +327,26 @@ void org::gdbus::codegen::glibmm::Test::TestObjectPathArray_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+std::vector<Glib::DBusObjectPathString>
+org::gdbus::codegen::glibmm::Test::TestObjectPathArray_sync(
+    const std::vector<Glib::DBusObjectPathString> & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestObjectPathArray_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestObjectPathArray", cancellable, base, timeout_msec);
+
+    std::vector<Glib::DBusObjectPathString> out_Param2;
+    Glib::Variant<std::vector<Glib::DBusObjectPathString>> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestStringArray(
     const std::vector<Glib::ustring> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -217,6 +370,26 @@ void org::gdbus::codegen::glibmm::Test::TestStringArray_finish(
     Glib::Variant<std::vector<Glib::ustring>> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+std::vector<Glib::ustring>
+org::gdbus::codegen::glibmm::Test::TestStringArray_sync(
+    const std::vector<Glib::ustring> & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestStringArray_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestStringArray", cancellable, base, timeout_msec);
+
+    std::vector<Glib::ustring> out_Param2;
+    Glib::Variant<std::vector<Glib::ustring>> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestByteString(
@@ -244,6 +417,26 @@ void org::gdbus::codegen::glibmm::Test::TestByteString_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+std::string
+org::gdbus::codegen::glibmm::Test::TestByteString_sync(
+    const std::string & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestByteString_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestByteString", cancellable, base, timeout_msec);
+
+    std::string out_Param2;
+    Glib::Variant<std::string> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestStruct(
     const std::tuple<Glib::ustring,Glib::ustring> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -267,6 +460,26 @@ void org::gdbus::codegen::glibmm::Test::TestStruct_finish(
     Glib::Variant<std::tuple<Glib::ustring,Glib::ustring>> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+std::tuple<Glib::ustring,Glib::ustring>
+org::gdbus::codegen::glibmm::Test::TestStruct_sync(
+    const std::tuple<Glib::ustring,Glib::ustring> & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestStruct_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestStruct", cancellable, base, timeout_msec);
+
+    std::tuple<Glib::ustring,Glib::ustring> out_Param2;
+    Glib::Variant<std::tuple<Glib::ustring,Glib::ustring>> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestStructArray(
@@ -294,6 +507,26 @@ void org::gdbus::codegen::glibmm::Test::TestStructArray_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+std::vector<std::tuple<guint32,Glib::ustring,gint32>>
+org::gdbus::codegen::glibmm::Test::TestStructArray_sync(
+    const std::vector<std::tuple<guint32,Glib::ustring,gint32>> & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestStructArray_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestStructArray", cancellable, base, timeout_msec);
+
+    std::vector<std::tuple<guint32,Glib::ustring,gint32>> out_Param2;
+    Glib::Variant<std::vector<std::tuple<guint32,Glib::ustring,gint32>>> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestDictStructArray(
     const std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> & arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -317,6 +550,26 @@ void org::gdbus::codegen::glibmm::Test::TestDictStructArray_finish(
     Glib::Variant<std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>>> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>>
+org::gdbus::codegen::glibmm::Test::TestDictStructArray_sync(
+    const std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestDictStructArray_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestDictStructArray", cancellable, base, timeout_msec);
+
+    std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> out_Param2;
+    Glib::Variant<std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>>> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestSignature(
@@ -344,6 +597,26 @@ void org::gdbus::codegen::glibmm::Test::TestSignature_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+Glib::DBusSignatureString
+org::gdbus::codegen::glibmm::Test::TestSignature_sync(
+    const Glib::DBusSignatureString & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestSignature_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestSignature", cancellable, base, timeout_msec);
+
+    Glib::DBusSignatureString out_Param2;
+    Glib::Variant<Glib::DBusSignatureString> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestObjectPath(
     const Glib::DBusObjectPathString & arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -367,6 +640,26 @@ void org::gdbus::codegen::glibmm::Test::TestObjectPath_finish(
     Glib::Variant<Glib::DBusObjectPathString> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+Glib::DBusObjectPathString
+org::gdbus::codegen::glibmm::Test::TestObjectPath_sync(
+    const Glib::DBusObjectPathString & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestObjectPath_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestObjectPath", cancellable, base, timeout_msec);
+
+    Glib::DBusObjectPathString out_Param2;
+    Glib::Variant<Glib::DBusObjectPathString> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestString(
@@ -394,6 +687,26 @@ void org::gdbus::codegen::glibmm::Test::TestString_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+Glib::ustring
+org::gdbus::codegen::glibmm::Test::TestString_sync(
+    const Glib::ustring & arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestString_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestString", cancellable, base, timeout_msec);
+
+    Glib::ustring out_Param2;
+    Glib::Variant<Glib::ustring> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestDouble(
     double arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -417,6 +730,26 @@ void org::gdbus::codegen::glibmm::Test::TestDouble_finish(
     Glib::Variant<double> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+double
+org::gdbus::codegen::glibmm::Test::TestDouble_sync(
+    double arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestDouble_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestDouble", cancellable, base, timeout_msec);
+
+    double out_Param2;
+    Glib::Variant<double> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestUInt64(
@@ -444,6 +777,26 @@ void org::gdbus::codegen::glibmm::Test::TestUInt64_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+guint64
+org::gdbus::codegen::glibmm::Test::TestUInt64_sync(
+    guint64 arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestUInt64_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestUInt64", cancellable, base, timeout_msec);
+
+    guint64 out_Param2;
+    Glib::Variant<guint64> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestInt64(
     gint64 arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -467,6 +820,26 @@ void org::gdbus::codegen::glibmm::Test::TestInt64_finish(
     Glib::Variant<gint64> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+gint64
+org::gdbus::codegen::glibmm::Test::TestInt64_sync(
+    gint64 arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestInt64_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestInt64", cancellable, base, timeout_msec);
+
+    gint64 out_Param2;
+    Glib::Variant<gint64> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestUInt(
@@ -494,6 +867,26 @@ void org::gdbus::codegen::glibmm::Test::TestUInt_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+guint32
+org::gdbus::codegen::glibmm::Test::TestUInt_sync(
+    guint32 arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestUInt_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestUInt", cancellable, base, timeout_msec);
+
+    guint32 out_Param2;
+    Glib::Variant<guint32> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestInt(
     gint32 arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -517,6 +910,26 @@ void org::gdbus::codegen::glibmm::Test::TestInt_finish(
     Glib::Variant<gint32> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+gint32
+org::gdbus::codegen::glibmm::Test::TestInt_sync(
+    gint32 arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestInt_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestInt", cancellable, base, timeout_msec);
+
+    gint32 out_Param2;
+    Glib::Variant<gint32> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestUInt16(
@@ -544,6 +957,26 @@ void org::gdbus::codegen::glibmm::Test::TestUInt16_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+guint16
+org::gdbus::codegen::glibmm::Test::TestUInt16_sync(
+    guint16 arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestUInt16_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestUInt16", cancellable, base, timeout_msec);
+
+    guint16 out_Param2;
+    Glib::Variant<guint16> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestInt16(
     gint16 arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -567,6 +1000,26 @@ void org::gdbus::codegen::glibmm::Test::TestInt16_finish(
     Glib::Variant<gint16> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+gint16
+org::gdbus::codegen::glibmm::Test::TestInt16_sync(
+    gint16 arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestInt16_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestInt16", cancellable, base, timeout_msec);
+
+    gint16 out_Param2;
+    Glib::Variant<gint16> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestChar(
@@ -594,6 +1047,26 @@ void org::gdbus::codegen::glibmm::Test::TestChar_finish(
     out_Param2 = out_Param2_v.get();
 }
 
+guchar
+org::gdbus::codegen::glibmm::Test::TestChar_sync(
+    guchar arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestChar_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestChar", cancellable, base, timeout_msec);
+
+    guchar out_Param2;
+    Glib::Variant<guchar> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
+}
+
 void org::gdbus::codegen::glibmm::Test::TestBoolean(
     bool arg_Param1,
     const Gio::SlotAsyncReady &callback,
@@ -617,6 +1090,26 @@ void org::gdbus::codegen::glibmm::Test::TestBoolean_finish(
     Glib::Variant<bool> out_Param2_v;
     wrapped.get_child(out_Param2_v, 0);
     out_Param2 = out_Param2_v.get();
+}
+
+bool
+org::gdbus::codegen::glibmm::Test::TestBoolean_sync(
+    bool arg_Param1,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestBoolean_pack(
+        arg_Param1);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestBoolean", cancellable, base, timeout_msec);
+
+    bool out_Param2;
+    Glib::Variant<bool> out_Param2_v;
+    wrapped.get_child(out_Param2_v, 0);
+    out_Param2 = out_Param2_v.get();
+    return out_Param2;
 }
 
 void org::gdbus::codegen::glibmm::Test::TestAll(
@@ -749,6 +1242,149 @@ void org::gdbus::codegen::glibmm::Test::TestAll_finish(
     out_out_Param16 = out_out_Param16_v.get();
 }
 
+std::tuple<std::vector<std::string>, std::vector<Glib::DBusObjectPathString>, std::vector<Glib::ustring>, std::string, Glib::DBusSignatureString, Glib::DBusObjectPathString, Glib::ustring, double, guint64, gint64, guint32, gint32, guint16, gint16, guchar, bool>
+org::gdbus::codegen::glibmm::Test::TestAll_sync(
+    const std::vector<std::string> & arg_in_Param1,
+    const std::vector<Glib::DBusObjectPathString> & arg_in_Param2,
+    const std::vector<Glib::ustring> & arg_in_Param3,
+    const std::string & arg_in_Param4,
+    const Glib::DBusSignatureString & arg_in_Param5,
+    const Glib::DBusObjectPathString & arg_in_Param6,
+    const Glib::ustring & arg_in_Param7,
+    double arg_in_Param8,
+    guint64 arg_in_Param9,
+    gint64 arg_in_Param10,
+    guint32 arg_in_Param11,
+    gint32 arg_in_Param12,
+    guint16 arg_in_Param13,
+    gint16 arg_in_Param14,
+    guchar arg_in_Param15,
+    bool arg_in_Param16,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestAll_pack(
+        arg_in_Param1,
+        arg_in_Param2,
+        arg_in_Param3,
+        arg_in_Param4,
+        arg_in_Param5,
+        arg_in_Param6,
+        arg_in_Param7,
+        arg_in_Param8,
+        arg_in_Param9,
+        arg_in_Param10,
+        arg_in_Param11,
+        arg_in_Param12,
+        arg_in_Param13,
+        arg_in_Param14,
+        arg_in_Param15,
+        arg_in_Param16);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestAll", cancellable, base, timeout_msec);
+
+    std::vector<std::string> out_out_Param1;
+    Glib::Variant<std::vector<std::string>> out_out_Param1_v;
+    wrapped.get_child(out_out_Param1_v, 0);
+    out_out_Param1 = out_out_Param1_v.get();
+
+    std::vector<Glib::DBusObjectPathString> out_out_Param2;
+    Glib::Variant<std::vector<Glib::DBusObjectPathString>> out_out_Param2_v;
+    wrapped.get_child(out_out_Param2_v, 1);
+    out_out_Param2 = out_out_Param2_v.get();
+
+    std::vector<Glib::ustring> out_out_Param3;
+    Glib::Variant<std::vector<Glib::ustring>> out_out_Param3_v;
+    wrapped.get_child(out_out_Param3_v, 2);
+    out_out_Param3 = out_out_Param3_v.get();
+
+    std::string out_out_Param4;
+    Glib::Variant<std::string> out_out_Param4_v;
+    wrapped.get_child(out_out_Param4_v, 3);
+    out_out_Param4 = out_out_Param4_v.get();
+
+    Glib::DBusSignatureString out_out_Param5;
+    Glib::Variant<Glib::DBusSignatureString> out_out_Param5_v;
+    wrapped.get_child(out_out_Param5_v, 4);
+    out_out_Param5 = out_out_Param5_v.get();
+
+    Glib::DBusObjectPathString out_out_Param6;
+    Glib::Variant<Glib::DBusObjectPathString> out_out_Param6_v;
+    wrapped.get_child(out_out_Param6_v, 5);
+    out_out_Param6 = out_out_Param6_v.get();
+
+    Glib::ustring out_out_Param7;
+    Glib::Variant<Glib::ustring> out_out_Param7_v;
+    wrapped.get_child(out_out_Param7_v, 6);
+    out_out_Param7 = out_out_Param7_v.get();
+
+    double out_out_Param8;
+    Glib::Variant<double> out_out_Param8_v;
+    wrapped.get_child(out_out_Param8_v, 7);
+    out_out_Param8 = out_out_Param8_v.get();
+
+    guint64 out_out_Param9;
+    Glib::Variant<guint64> out_out_Param9_v;
+    wrapped.get_child(out_out_Param9_v, 8);
+    out_out_Param9 = out_out_Param9_v.get();
+
+    gint64 out_out_Param10;
+    Glib::Variant<gint64> out_out_Param10_v;
+    wrapped.get_child(out_out_Param10_v, 9);
+    out_out_Param10 = out_out_Param10_v.get();
+
+    guint32 out_out_Param11;
+    Glib::Variant<guint32> out_out_Param11_v;
+    wrapped.get_child(out_out_Param11_v, 10);
+    out_out_Param11 = out_out_Param11_v.get();
+
+    gint32 out_out_Param12;
+    Glib::Variant<gint32> out_out_Param12_v;
+    wrapped.get_child(out_out_Param12_v, 11);
+    out_out_Param12 = out_out_Param12_v.get();
+
+    guint16 out_out_Param13;
+    Glib::Variant<guint16> out_out_Param13_v;
+    wrapped.get_child(out_out_Param13_v, 12);
+    out_out_Param13 = out_out_Param13_v.get();
+
+    gint16 out_out_Param14;
+    Glib::Variant<gint16> out_out_Param14_v;
+    wrapped.get_child(out_out_Param14_v, 13);
+    out_out_Param14 = out_out_Param14_v.get();
+
+    guchar out_out_Param15;
+    Glib::Variant<guchar> out_out_Param15_v;
+    wrapped.get_child(out_out_Param15_v, 14);
+    out_out_Param15 = out_out_Param15_v.get();
+
+    bool out_out_Param16;
+    Glib::Variant<bool> out_out_Param16_v;
+    wrapped.get_child(out_out_Param16_v, 15);
+    out_out_Param16 = out_out_Param16_v.get();
+
+    return std::make_tuple(
+        std::move(out_out_Param1),
+        std::move(out_out_Param2),
+        std::move(out_out_Param3),
+        std::move(out_out_Param4),
+        std::move(out_out_Param5),
+        std::move(out_out_Param6),
+        std::move(out_out_Param7),
+        std::move(out_out_Param8),
+        std::move(out_out_Param9),
+        std::move(out_out_Param10),
+        std::move(out_out_Param11),
+        std::move(out_out_Param12),
+        std::move(out_out_Param13),
+        std::move(out_out_Param14),
+        std::move(out_out_Param15),
+        std::move(out_out_Param16)
+    );
+}
+
 void org::gdbus::codegen::glibmm::Test::TestTriggerInternalPropertyChange(
     gint32 arg_NewPropertyValue,
     const Gio::SlotAsyncReady &callback,
@@ -767,6 +1403,21 @@ void org::gdbus::codegen::glibmm::Test::TestTriggerInternalPropertyChange_finish
 {
     Glib::VariantContainerBase wrapped;
     wrapped = m_proxy->call_finish(result);
+}
+
+void
+org::gdbus::codegen::glibmm::Test::TestTriggerInternalPropertyChange_sync(
+    gint32 arg_NewPropertyValue,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestTriggerInternalPropertyChange_pack(
+        arg_NewPropertyValue);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestTriggerInternalPropertyChange", cancellable, base, timeout_msec);
+
 }
 
 std::vector<std::string> org::gdbus::codegen::glibmm::Test::TestPropReadByteStringArray_get()

--- a/tests/data/many-types/input_proxy.h
+++ b/tests/data/many-types/input_proxy.h
@@ -408,96 +408,112 @@ public:
 
     void TestPropWriteByteStringArray_set(const std::vector<std::string> &, const Gio::SlotAsyncReady &);
     void TestPropWriteByteStringArray_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteByteStringArray_set_sync(const std::vector<std::string> &);
     sigc::signal<void> &TestPropWriteByteStringArray_changed() {
         return m_TestPropWriteByteStringArray_changed;
     }
 
     void TestPropWriteObjectPathArray_set(const std::vector<Glib::DBusObjectPathString> &, const Gio::SlotAsyncReady &);
     void TestPropWriteObjectPathArray_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteObjectPathArray_set_sync(const std::vector<Glib::DBusObjectPathString> &);
     sigc::signal<void> &TestPropWriteObjectPathArray_changed() {
         return m_TestPropWriteObjectPathArray_changed;
     }
 
     void TestPropWriteStringArray_set(const std::vector<Glib::ustring> &, const Gio::SlotAsyncReady &);
     void TestPropWriteStringArray_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteStringArray_set_sync(const std::vector<Glib::ustring> &);
     sigc::signal<void> &TestPropWriteStringArray_changed() {
         return m_TestPropWriteStringArray_changed;
     }
 
     void TestPropWriteByteString_set(const std::string &, const Gio::SlotAsyncReady &);
     void TestPropWriteByteString_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteByteString_set_sync(const std::string &);
     sigc::signal<void> &TestPropWriteByteString_changed() {
         return m_TestPropWriteByteString_changed;
     }
 
     void TestPropWriteSignature_set(const Glib::DBusSignatureString &, const Gio::SlotAsyncReady &);
     void TestPropWriteSignature_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteSignature_set_sync(const Glib::DBusSignatureString &);
     sigc::signal<void> &TestPropWriteSignature_changed() {
         return m_TestPropWriteSignature_changed;
     }
 
     void TestPropWriteObjectPath_set(const Glib::DBusObjectPathString &, const Gio::SlotAsyncReady &);
     void TestPropWriteObjectPath_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteObjectPath_set_sync(const Glib::DBusObjectPathString &);
     sigc::signal<void> &TestPropWriteObjectPath_changed() {
         return m_TestPropWriteObjectPath_changed;
     }
 
     void TestPropWriteString_set(const Glib::ustring &, const Gio::SlotAsyncReady &);
     void TestPropWriteString_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteString_set_sync(const Glib::ustring &);
     sigc::signal<void> &TestPropWriteString_changed() {
         return m_TestPropWriteString_changed;
     }
 
     void TestPropWriteDouble_set(double, const Gio::SlotAsyncReady &);
     void TestPropWriteDouble_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteDouble_set_sync(double);
     sigc::signal<void> &TestPropWriteDouble_changed() {
         return m_TestPropWriteDouble_changed;
     }
 
     void TestPropWriteUInt64_set(guint64, const Gio::SlotAsyncReady &);
     void TestPropWriteUInt64_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteUInt64_set_sync(guint64);
     sigc::signal<void> &TestPropWriteUInt64_changed() {
         return m_TestPropWriteUInt64_changed;
     }
 
     void TestPropWriteInt64_set(gint64, const Gio::SlotAsyncReady &);
     void TestPropWriteInt64_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteInt64_set_sync(gint64);
     sigc::signal<void> &TestPropWriteInt64_changed() {
         return m_TestPropWriteInt64_changed;
     }
 
     void TestPropWriteUInt_set(guint32, const Gio::SlotAsyncReady &);
     void TestPropWriteUInt_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteUInt_set_sync(guint32);
     sigc::signal<void> &TestPropWriteUInt_changed() {
         return m_TestPropWriteUInt_changed;
     }
 
     void TestPropWriteInt_set(gint32, const Gio::SlotAsyncReady &);
     void TestPropWriteInt_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteInt_set_sync(gint32);
     sigc::signal<void> &TestPropWriteInt_changed() {
         return m_TestPropWriteInt_changed;
     }
 
     void TestPropWriteUInt16_set(guint16, const Gio::SlotAsyncReady &);
     void TestPropWriteUInt16_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteUInt16_set_sync(guint16);
     sigc::signal<void> &TestPropWriteUInt16_changed() {
         return m_TestPropWriteUInt16_changed;
     }
 
     void TestPropWriteInt16_set(gint16, const Gio::SlotAsyncReady &);
     void TestPropWriteInt16_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteInt16_set_sync(gint16);
     sigc::signal<void> &TestPropWriteInt16_changed() {
         return m_TestPropWriteInt16_changed;
     }
 
     void TestPropWriteChar_set(guchar, const Gio::SlotAsyncReady &);
     void TestPropWriteChar_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteChar_set_sync(guchar);
     sigc::signal<void> &TestPropWriteChar_changed() {
         return m_TestPropWriteChar_changed;
     }
 
     void TestPropWriteBoolean_set(bool, const Gio::SlotAsyncReady &);
     void TestPropWriteBoolean_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropWriteBoolean_set_sync(bool);
     sigc::signal<void> &TestPropWriteBoolean_changed() {
         return m_TestPropWriteBoolean_changed;
     }
@@ -505,6 +521,7 @@ public:
     std::vector<std::string> TestPropReadWriteByteStringArray_get();
     void TestPropReadWriteByteStringArray_set(const std::vector<std::string> &, const Gio::SlotAsyncReady &);
     void TestPropReadWriteByteStringArray_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteByteStringArray_set_sync(const std::vector<std::string> &);
     sigc::signal<void> &TestPropReadWriteByteStringArray_changed() {
         return m_TestPropReadWriteByteStringArray_changed;
     }
@@ -512,6 +529,7 @@ public:
     std::vector<Glib::DBusObjectPathString> TestPropReadWriteObjectPathArray_get();
     void TestPropReadWriteObjectPathArray_set(const std::vector<Glib::DBusObjectPathString> &, const Gio::SlotAsyncReady &);
     void TestPropReadWriteObjectPathArray_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteObjectPathArray_set_sync(const std::vector<Glib::DBusObjectPathString> &);
     sigc::signal<void> &TestPropReadWriteObjectPathArray_changed() {
         return m_TestPropReadWriteObjectPathArray_changed;
     }
@@ -519,6 +537,7 @@ public:
     std::vector<Glib::ustring> TestPropReadWriteStringArray_get();
     void TestPropReadWriteStringArray_set(const std::vector<Glib::ustring> &, const Gio::SlotAsyncReady &);
     void TestPropReadWriteStringArray_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteStringArray_set_sync(const std::vector<Glib::ustring> &);
     sigc::signal<void> &TestPropReadWriteStringArray_changed() {
         return m_TestPropReadWriteStringArray_changed;
     }
@@ -526,6 +545,7 @@ public:
     std::string TestPropReadWriteByteString_get();
     void TestPropReadWriteByteString_set(const std::string &, const Gio::SlotAsyncReady &);
     void TestPropReadWriteByteString_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteByteString_set_sync(const std::string &);
     sigc::signal<void> &TestPropReadWriteByteString_changed() {
         return m_TestPropReadWriteByteString_changed;
     }
@@ -533,6 +553,7 @@ public:
     Glib::DBusSignatureString TestPropReadWriteSignature_get();
     void TestPropReadWriteSignature_set(const Glib::DBusSignatureString &, const Gio::SlotAsyncReady &);
     void TestPropReadWriteSignature_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteSignature_set_sync(const Glib::DBusSignatureString &);
     sigc::signal<void> &TestPropReadWriteSignature_changed() {
         return m_TestPropReadWriteSignature_changed;
     }
@@ -540,6 +561,7 @@ public:
     Glib::DBusObjectPathString TestPropReadWriteObjectPath_get();
     void TestPropReadWriteObjectPath_set(const Glib::DBusObjectPathString &, const Gio::SlotAsyncReady &);
     void TestPropReadWriteObjectPath_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteObjectPath_set_sync(const Glib::DBusObjectPathString &);
     sigc::signal<void> &TestPropReadWriteObjectPath_changed() {
         return m_TestPropReadWriteObjectPath_changed;
     }
@@ -547,6 +569,7 @@ public:
     Glib::ustring TestPropReadWriteString_get();
     void TestPropReadWriteString_set(const Glib::ustring &, const Gio::SlotAsyncReady &);
     void TestPropReadWriteString_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteString_set_sync(const Glib::ustring &);
     sigc::signal<void> &TestPropReadWriteString_changed() {
         return m_TestPropReadWriteString_changed;
     }
@@ -554,6 +577,7 @@ public:
     double TestPropReadWriteDouble_get();
     void TestPropReadWriteDouble_set(double, const Gio::SlotAsyncReady &);
     void TestPropReadWriteDouble_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteDouble_set_sync(double);
     sigc::signal<void> &TestPropReadWriteDouble_changed() {
         return m_TestPropReadWriteDouble_changed;
     }
@@ -561,6 +585,7 @@ public:
     guint64 TestPropReadWriteUInt64_get();
     void TestPropReadWriteUInt64_set(guint64, const Gio::SlotAsyncReady &);
     void TestPropReadWriteUInt64_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteUInt64_set_sync(guint64);
     sigc::signal<void> &TestPropReadWriteUInt64_changed() {
         return m_TestPropReadWriteUInt64_changed;
     }
@@ -568,6 +593,7 @@ public:
     gint64 TestPropReadWriteInt64_get();
     void TestPropReadWriteInt64_set(gint64, const Gio::SlotAsyncReady &);
     void TestPropReadWriteInt64_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteInt64_set_sync(gint64);
     sigc::signal<void> &TestPropReadWriteInt64_changed() {
         return m_TestPropReadWriteInt64_changed;
     }
@@ -575,6 +601,7 @@ public:
     guint32 TestPropReadWriteUInt_get();
     void TestPropReadWriteUInt_set(guint32, const Gio::SlotAsyncReady &);
     void TestPropReadWriteUInt_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteUInt_set_sync(guint32);
     sigc::signal<void> &TestPropReadWriteUInt_changed() {
         return m_TestPropReadWriteUInt_changed;
     }
@@ -582,6 +609,7 @@ public:
     gint32 TestPropReadWriteInt_get();
     void TestPropReadWriteInt_set(gint32, const Gio::SlotAsyncReady &);
     void TestPropReadWriteInt_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteInt_set_sync(gint32);
     sigc::signal<void> &TestPropReadWriteInt_changed() {
         return m_TestPropReadWriteInt_changed;
     }
@@ -589,6 +617,7 @@ public:
     guint16 TestPropReadWriteUInt16_get();
     void TestPropReadWriteUInt16_set(guint16, const Gio::SlotAsyncReady &);
     void TestPropReadWriteUInt16_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteUInt16_set_sync(guint16);
     sigc::signal<void> &TestPropReadWriteUInt16_changed() {
         return m_TestPropReadWriteUInt16_changed;
     }
@@ -596,6 +625,7 @@ public:
     gint16 TestPropReadWriteInt16_get();
     void TestPropReadWriteInt16_set(gint16, const Gio::SlotAsyncReady &);
     void TestPropReadWriteInt16_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteInt16_set_sync(gint16);
     sigc::signal<void> &TestPropReadWriteInt16_changed() {
         return m_TestPropReadWriteInt16_changed;
     }
@@ -603,6 +633,7 @@ public:
     guchar TestPropReadWriteChar_get();
     void TestPropReadWriteChar_set(guchar, const Gio::SlotAsyncReady &);
     void TestPropReadWriteChar_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteChar_set_sync(guchar);
     sigc::signal<void> &TestPropReadWriteChar_changed() {
         return m_TestPropReadWriteChar_changed;
     }
@@ -610,6 +641,7 @@ public:
     bool TestPropReadWriteBoolean_get();
     void TestPropReadWriteBoolean_set(bool, const Gio::SlotAsyncReady &);
     void TestPropReadWriteBoolean_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropReadWriteBoolean_set_sync(bool);
     sigc::signal<void> &TestPropReadWriteBoolean_changed() {
         return m_TestPropReadWriteBoolean_changed;
     }
@@ -617,6 +649,7 @@ public:
     gint32 TestPropInternalReadWritePropertyChange_get();
     void TestPropInternalReadWritePropertyChange_set(gint32, const Gio::SlotAsyncReady &);
     void TestPropInternalReadWritePropertyChange_set_finish(const Glib::RefPtr<Gio::AsyncResult> &);
+    void TestPropInternalReadWritePropertyChange_set_sync(gint32);
     sigc::signal<void> &TestPropInternalReadWritePropertyChange_changed() {
         return m_TestPropInternalReadWritePropertyChange_changed;
     }

--- a/tests/data/many-types/input_proxy.h
+++ b/tests/data/many-types/input_proxy.h
@@ -21,6 +21,13 @@ public:
 
     static Glib::RefPtr<Test> createForBusFinish (Glib::RefPtr<Gio::AsyncResult> result);
 
+    static Glib::RefPtr<Test> createForBus_sync(
+        Gio::DBus::BusType busType,
+        Gio::DBus::ProxyFlags proxyFlags,
+        const std::string &name,
+        const std::string &objectPath,
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+
     Glib::RefPtr<Gio::DBus::Proxy> dbusProxy() const { return m_proxy; }
 
     void TestStringVariantDict(

--- a/tests/data/many-types/input_proxy.h
+++ b/tests/data/many-types/input_proxy.h
@@ -53,46 +53,22 @@ public:
         std::map<guint32,gint32> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
-    template <typename T>
     void TestVariant(
-        T Param1,
-        const Gio::SlotAsyncReady &callback,
+        const Glib::VariantBase & Param1,
+        const Gio::SlotAsyncReady &slot,
         const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
-        int timeout_msec = -1)
-    {
-        Glib::VariantContainerBase base;
-        Glib::Variant<Glib::Variant<T>> variantValue =
-            Glib::Variant<Glib::Variant<T>>::create(Glib::Variant<T>::create(Param1));
-        Glib::VariantBase params = variantValue;
-        base = Glib::VariantContainerBase::create_tuple(params);
-
-        m_proxy->call( "TestVariant", callback, cancellable, base, timeout_msec);
-    }
+        int timeout_msec = -1);
 
     void TestVariant_finish (
         Glib::VariantBase &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
-    template <typename T>
     void TestVariant2(
         const Glib::ustring & Param1,
-        T Param2,
-        const Gio::SlotAsyncReady &callback,
+        const Glib::VariantBase & Param2,
+        const Gio::SlotAsyncReady &slot,
         const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
-        int timeout_msec = -1)
-    {
-        Glib::VariantContainerBase base;
-        std::vector<Glib::VariantBase> params;
-        Glib::Variant<Glib::ustring> Param1_param =
-    Glib::Variant<Glib::ustring>::create(Param1);
-        params.push_back(Param1_param);
-        Glib::Variant<Glib::Variant<T>> Param2_variantValue =
-            Glib::Variant<Glib::Variant<T>>::create(Glib::Variant<T>::create(Param2));
-        params.push_back(Param2_variantValue);
-        base = Glib::VariantContainerBase::create_tuple(params);
-
-        m_proxy->call( "TestVariant2", callback, cancellable, base, timeout_msec);
-    }
+        int timeout_msec = -1);
 
     void TestVariant2_finish (
         Glib::ustring &Param3,

--- a/tests/data/many-types/input_proxy.h
+++ b/tests/data/many-types/input_proxy.h
@@ -73,6 +73,32 @@ public:
         Glib::VariantBase &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    template <typename T>
+    void TestVariant2(
+        const Glib::ustring & Param1,
+        T Param2,
+        const Gio::SlotAsyncReady &callback,
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1)
+    {
+        Glib::VariantContainerBase base;
+        std::vector<Glib::VariantBase> params;
+        Glib::Variant<Glib::ustring> Param1_param =
+    Glib::Variant<Glib::ustring>::create(Param1);
+        params.push_back(Param1_param);
+        Glib::Variant<Glib::Variant<T>> Param2_variantValue =
+            Glib::Variant<Glib::Variant<T>>::create(Glib::Variant<T>::create(Param2));
+        params.push_back(Param2_variantValue);
+        base = Glib::VariantContainerBase::create_tuple(params);
+
+        m_proxy->call( "TestVariant2", callback, cancellable, base, timeout_msec);
+    }
+
+    void TestVariant2_finish (
+        Glib::ustring &Param3,
+        Glib::VariantBase &Param4,
+        const Glib::RefPtr<Gio::AsyncResult> &res);
+
     void TestByteStringArray(
         const std::vector<std::string> & Param1,
         const Gio::SlotAsyncReady &slot,

--- a/tests/data/many-types/input_proxy.h
+++ b/tests/data/many-types/input_proxy.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <tuple>
 #include <vector>
 #include <glibmm.h>
 #include <giomm.h>
@@ -40,6 +41,11 @@ public:
         std::map<Glib::ustring,Glib::VariantBase> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    std::map<Glib::ustring,Glib::VariantBase>
+    TestStringVariantDict_sync(
+        const std::map<Glib::ustring,Glib::VariantBase> & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestStringStringDict(
         const std::map<Glib::ustring,Glib::ustring> & Param1,
         const Gio::SlotAsyncReady &slot,
@@ -49,6 +55,11 @@ public:
     void TestStringStringDict_finish (
         std::map<Glib::ustring,Glib::ustring> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    std::map<Glib::ustring,Glib::ustring>
+    TestStringStringDict_sync(
+        const std::map<Glib::ustring,Glib::ustring> & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestUintIntDict(
         const std::map<guint32,gint32> & Param1,
@@ -60,6 +71,11 @@ public:
         std::map<guint32,gint32> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    std::map<guint32,gint32>
+    TestUintIntDict_sync(
+        const std::map<guint32,gint32> & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestVariant(
         const Glib::VariantBase & Param1,
         const Gio::SlotAsyncReady &slot,
@@ -69,6 +85,11 @@ public:
     void TestVariant_finish (
         Glib::VariantBase &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    Glib::VariantBase
+    TestVariant_sync(
+        const Glib::VariantBase & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestVariant2(
         const Glib::ustring & Param1,
@@ -82,6 +103,11 @@ public:
         Glib::VariantBase &Param4,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    std::tuple<Glib::ustring, Glib::VariantBase>
+    TestVariant2_sync(
+        const Glib::ustring & Param1,        const Glib::VariantBase & Param2,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestByteStringArray(
         const std::vector<std::string> & Param1,
         const Gio::SlotAsyncReady &slot,
@@ -91,6 +117,11 @@ public:
     void TestByteStringArray_finish (
         std::vector<std::string> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    std::vector<std::string>
+    TestByteStringArray_sync(
+        const std::vector<std::string> & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestObjectPathArray(
         const std::vector<Glib::DBusObjectPathString> & Param1,
@@ -102,6 +133,11 @@ public:
         std::vector<Glib::DBusObjectPathString> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    std::vector<Glib::DBusObjectPathString>
+    TestObjectPathArray_sync(
+        const std::vector<Glib::DBusObjectPathString> & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestStringArray(
         const std::vector<Glib::ustring> & Param1,
         const Gio::SlotAsyncReady &slot,
@@ -111,6 +147,11 @@ public:
     void TestStringArray_finish (
         std::vector<Glib::ustring> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    std::vector<Glib::ustring>
+    TestStringArray_sync(
+        const std::vector<Glib::ustring> & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestByteString(
         const std::string & Param1,
@@ -122,6 +163,11 @@ public:
         std::string &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    std::string
+    TestByteString_sync(
+        const std::string & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestStruct(
         const std::tuple<Glib::ustring,Glib::ustring> & Param1,
         const Gio::SlotAsyncReady &slot,
@@ -131,6 +177,11 @@ public:
     void TestStruct_finish (
         std::tuple<Glib::ustring,Glib::ustring> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    std::tuple<Glib::ustring,Glib::ustring>
+    TestStruct_sync(
+        const std::tuple<Glib::ustring,Glib::ustring> & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestStructArray(
         const std::vector<std::tuple<guint32,Glib::ustring,gint32>> & Param1,
@@ -142,6 +193,11 @@ public:
         std::vector<std::tuple<guint32,Glib::ustring,gint32>> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    std::vector<std::tuple<guint32,Glib::ustring,gint32>>
+    TestStructArray_sync(
+        const std::vector<std::tuple<guint32,Glib::ustring,gint32>> & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestDictStructArray(
         const std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> & Param1,
         const Gio::SlotAsyncReady &slot,
@@ -151,6 +207,11 @@ public:
     void TestDictStructArray_finish (
         std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>>
+    TestDictStructArray_sync(
+        const std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestSignature(
         const Glib::DBusSignatureString & Param1,
@@ -162,6 +223,11 @@ public:
         Glib::DBusSignatureString &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    Glib::DBusSignatureString
+    TestSignature_sync(
+        const Glib::DBusSignatureString & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestObjectPath(
         const Glib::DBusObjectPathString & Param1,
         const Gio::SlotAsyncReady &slot,
@@ -171,6 +237,11 @@ public:
     void TestObjectPath_finish (
         Glib::DBusObjectPathString &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    Glib::DBusObjectPathString
+    TestObjectPath_sync(
+        const Glib::DBusObjectPathString & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestString(
         const Glib::ustring & Param1,
@@ -182,6 +253,11 @@ public:
         Glib::ustring &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    Glib::ustring
+    TestString_sync(
+        const Glib::ustring & Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestDouble(
         double Param1,
         const Gio::SlotAsyncReady &slot,
@@ -191,6 +267,11 @@ public:
     void TestDouble_finish (
         double &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    double
+    TestDouble_sync(
+        double Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestUInt64(
         guint64 Param1,
@@ -202,6 +283,11 @@ public:
         guint64 &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    guint64
+    TestUInt64_sync(
+        guint64 Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestInt64(
         gint64 Param1,
         const Gio::SlotAsyncReady &slot,
@@ -211,6 +297,11 @@ public:
     void TestInt64_finish (
         gint64 &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    gint64
+    TestInt64_sync(
+        gint64 Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestUInt(
         guint32 Param1,
@@ -222,6 +313,11 @@ public:
         guint32 &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    guint32
+    TestUInt_sync(
+        guint32 Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestInt(
         gint32 Param1,
         const Gio::SlotAsyncReady &slot,
@@ -231,6 +327,11 @@ public:
     void TestInt_finish (
         gint32 &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    gint32
+    TestInt_sync(
+        gint32 Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestUInt16(
         guint16 Param1,
@@ -242,6 +343,11 @@ public:
         guint16 &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    guint16
+    TestUInt16_sync(
+        guint16 Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestInt16(
         gint16 Param1,
         const Gio::SlotAsyncReady &slot,
@@ -251,6 +357,11 @@ public:
     void TestInt16_finish (
         gint16 &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    gint16
+    TestInt16_sync(
+        gint16 Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestChar(
         guchar Param1,
@@ -262,6 +373,11 @@ public:
         guchar &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    guchar
+    TestChar_sync(
+        guchar Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestBoolean(
         bool Param1,
         const Gio::SlotAsyncReady &slot,
@@ -271,6 +387,11 @@ public:
     void TestBoolean_finish (
         bool &Param2,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    bool
+    TestBoolean_sync(
+        bool Param1,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     void TestAll(
         const std::vector<std::string> & in_Param1,
@@ -312,6 +433,11 @@ public:
         bool &out_Param16,
         const Glib::RefPtr<Gio::AsyncResult> &res);
 
+    std::tuple<std::vector<std::string>, std::vector<Glib::DBusObjectPathString>, std::vector<Glib::ustring>, std::string, Glib::DBusSignatureString, Glib::DBusObjectPathString, Glib::ustring, double, guint64, gint64, guint32, gint32, guint16, gint16, guchar, bool>
+    TestAll_sync(
+        const std::vector<std::string> & in_Param1,        const std::vector<Glib::DBusObjectPathString> & in_Param2,        const std::vector<Glib::ustring> & in_Param3,        const std::string & in_Param4,        const Glib::DBusSignatureString & in_Param5,        const Glib::DBusObjectPathString & in_Param6,        const Glib::ustring & in_Param7,        double in_Param8,        guint64 in_Param9,        gint64 in_Param10,        guint32 in_Param11,        gint32 in_Param12,        guint16 in_Param13,        gint16 in_Param14,        guchar in_Param15,        bool in_Param16,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
+
     void TestTriggerInternalPropertyChange(
         gint32 NewPropertyValue,
         const Gio::SlotAsyncReady &slot,
@@ -320,6 +446,11 @@ public:
 
     void TestTriggerInternalPropertyChange_finish (
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    void
+    TestTriggerInternalPropertyChange_sync(
+        gint32 NewPropertyValue,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     std::vector<std::string> TestPropReadByteStringArray_get();
     sigc::signal<void> &TestPropReadByteStringArray_changed() {

--- a/tests/data/many-types/input_stub.cpp
+++ b/tests/data/many-types/input_stub.cpp
@@ -453,11 +453,9 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
     }
 
     if (method_name.compare("TestVariant") == 0) {
-        Glib::VariantContainerBase containerBase = parameters;
-        GVariant *output0;
-        g_variant_get_child(containerBase.gobj(), 0, "v", &output0);
-        Glib::VariantBase p_Param1 =
-            Glib::VariantBase(output0);
+        Glib::Variant<Glib::VariantBase> base_Param1;
+        parameters.get_child(base_Param1, 0);
+        Glib::VariantBase p_Param1 = base_Param1.get();
 
         TestVariant(
             (p_Param1),
@@ -465,15 +463,13 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
     }
 
     if (method_name.compare("TestVariant2") == 0) {
-        Glib::VariantContainerBase containerBase = parameters;
         Glib::Variant<Glib::ustring> base_Param1;
         parameters.get_child(base_Param1, 0);
         Glib::ustring p_Param1 = base_Param1.get();
 
-        GVariant *output1;
-        g_variant_get_child(containerBase.gobj(), 1, "v", &output1);
-        Glib::VariantBase p_Param2 =
-            Glib::VariantBase(output1);
+        Glib::Variant<Glib::VariantBase> base_Param2;
+        parameters.get_child(base_Param2, 1);
+        Glib::VariantBase p_Param2 = base_Param2.get();
 
         TestVariant2(
             (p_Param1),

--- a/tests/data/many-types/input_stub.cpp
+++ b/tests/data/many-types/input_stub.cpp
@@ -28,6 +28,13 @@ static const char interfaceXml0[] = R"XML_DELIMITER(<!DOCTYPE node PUBLIC "-//fr
        <arg type="v" name="Param2" direction="out"></arg>
     </method>
 
+    <method name="TestVariant2">
+       <arg type="s" name="Param1" direction="in"></arg>
+       <arg type="v" name="Param2" direction="in"></arg>
+       <arg type="s" name="Param3" direction="out"></arg>
+       <arg type="v" name="Param4" direction="out"></arg>
+    </method>
+
     <method name="TestByteStringArray">
         <arg type="aay" name="Param1" direction="in"></arg>
         <arg type="aay" name="Param2" direction="out"></arg>
@@ -454,6 +461,23 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
 
         TestVariant(
             (p_Param1),
+            MethodInvocation(invocation));
+    }
+
+    if (method_name.compare("TestVariant2") == 0) {
+        Glib::VariantContainerBase containerBase = parameters;
+        Glib::Variant<Glib::ustring> base_Param1;
+        parameters.get_child(base_Param1, 0);
+        Glib::ustring p_Param1 = base_Param1.get();
+
+        GVariant *output1;
+        g_variant_get_child(containerBase.gobj(), 1, "v", &output1);
+        Glib::VariantBase p_Param2 =
+            Glib::VariantBase(output1);
+
+        TestVariant2(
+            (p_Param1),
+            (p_Param2),
             MethodInvocation(invocation));
     }
 

--- a/tests/data/many-types/input_stub.h
+++ b/tests/data/many-types/input_stub.h
@@ -85,6 +85,10 @@ protected:
     virtual void TestVariant(
         const Glib::VariantBase & Param1,
         MethodInvocation invocation) = 0;
+    virtual void TestVariant2(
+        const Glib::ustring & Param1,
+        const Glib::VariantBase & Param2,
+        MethodInvocation invocation) = 0;
     virtual void TestByteStringArray(
         const std::vector<std::string> & Param1,
         MethodInvocation invocation) = 0;
@@ -701,6 +705,16 @@ public:
     void ret(const Glib::VariantBase & p0) {
         std::vector<Glib::VariantBase> vlist;
         vlist.push_back(p0);
+
+        m_message->return_value(Glib::Variant<Glib::VariantBase>::create_tuple(vlist));
+    }
+
+    void ret(const Glib::ustring & p0, const Glib::VariantBase & p1) {
+        std::vector<Glib::VariantBase> vlist;
+        Glib::Variant<Glib::ustring> var0 =
+            Glib::Variant<Glib::ustring>::create(p0);
+        vlist.push_back(var0);
+        vlist.push_back(p1);
 
         m_message->return_value(Glib::Variant<Glib::VariantBase>::create_tuple(vlist));
     }

--- a/tests/data/simple/input_proxy.cpp
+++ b/tests/data/simple/input_proxy.cpp
@@ -6,6 +6,8 @@
 
 #include "OUTPUT_DIR/input_proxy.h"
 
+#include <utility>
+
 void org::gdbus::codegen::glibmm::Test::TestCall(
     gint32 arg_Param1,
     const std::map<Glib::ustring,Glib::VariantBase> & arg_Param2,
@@ -36,6 +38,37 @@ void org::gdbus::codegen::glibmm::Test::TestCall_finish(
     Glib::Variant<std::map<Glib::ustring,Glib::VariantBase>> out_Param4_v;
     wrapped.get_child(out_Param4_v, 1);
     out_Param4 = out_Param4_v.get();
+}
+
+std::tuple<Glib::ustring, std::map<Glib::ustring,Glib::VariantBase>>
+org::gdbus::codegen::glibmm::Test::TestCall_sync(
+    gint32 arg_Param1,
+    const std::map<Glib::ustring,Glib::VariantBase> & arg_Param2,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable,
+    int timeout_msec)
+{
+    Glib::VariantContainerBase base;
+    base = TestTypeWrap::TestCall_pack(
+        arg_Param1,
+        arg_Param2);
+
+    Glib::VariantContainerBase wrapped;
+    wrapped = m_proxy->call_sync("TestCall", cancellable, base, timeout_msec);
+
+    Glib::ustring out_Param3;
+    Glib::Variant<Glib::ustring> out_Param3_v;
+    wrapped.get_child(out_Param3_v, 0);
+    out_Param3 = out_Param3_v.get();
+
+    std::map<Glib::ustring,Glib::VariantBase> out_Param4;
+    Glib::Variant<std::map<Glib::ustring,Glib::VariantBase>> out_Param4_v;
+    wrapped.get_child(out_Param4_v, 1);
+    out_Param4 = out_Param4_v.get();
+
+    return std::make_tuple(
+        std::move(out_Param3),
+        std::move(out_Param4)
+    );
 }
 
 std::vector<Glib::ustring> org::gdbus::codegen::glibmm::Test::TestPropReadStringArray_get()

--- a/tests/data/simple/input_proxy.cpp
+++ b/tests/data/simple/input_proxy.cpp
@@ -117,3 +117,23 @@ Glib::RefPtr<org::gdbus::codegen::glibmm::Test> org::gdbus::codegen::glibmm::Tes
         new org::gdbus::codegen::glibmm::Test(proxy);
     return Glib::RefPtr<org::gdbus::codegen::glibmm::Test>(p);
 }
+
+Glib::RefPtr<org::gdbus::codegen::glibmm::Test> org::gdbus::codegen::glibmm::Test::createForBus_sync(
+    Gio::DBus::BusType busType,
+    Gio::DBus::ProxyFlags proxyFlags,
+    const std::string &name,
+    const std::string &objectPath,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+{
+    Glib::RefPtr<Gio::DBus::Proxy> proxy =
+        Gio::DBus::Proxy::create_for_bus_sync(busType,
+            name,
+            objectPath,
+            "org.gdbus.codegen.glibmm.Test",
+            cancellable,
+            Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+            proxyFlags);
+    org::gdbus::codegen::glibmm::Test *p =
+        new org::gdbus::codegen::glibmm::Test(proxy);
+    return Glib::RefPtr<org::gdbus::codegen::glibmm::Test>(p);
+}

--- a/tests/data/simple/input_proxy.h
+++ b/tests/data/simple/input_proxy.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <tuple>
 #include <vector>
 #include <glibmm.h>
 #include <giomm.h>
@@ -41,6 +42,11 @@ public:
         Glib::ustring &Param3,
         std::map<Glib::ustring,Glib::VariantBase> &Param4,
         const Glib::RefPtr<Gio::AsyncResult> &res);
+
+    std::tuple<Glib::ustring, std::map<Glib::ustring,Glib::VariantBase>>
+    TestCall_sync(
+        gint32 Param1,        const std::map<Glib::ustring,Glib::VariantBase> & Param2,const Glib::RefPtr<Gio::Cancellable> &cancellable = {},
+        int timeout_msec = -1);
 
     std::vector<Glib::ustring> TestPropReadStringArray_get();
     sigc::signal<void> &TestPropReadStringArray_changed() {

--- a/tests/data/simple/input_proxy.h
+++ b/tests/data/simple/input_proxy.h
@@ -21,6 +21,13 @@ public:
 
     static Glib::RefPtr<Test> createForBusFinish (Glib::RefPtr<Gio::AsyncResult> result);
 
+    static Glib::RefPtr<Test> createForBus_sync(
+        Gio::DBus::BusType busType,
+        Gio::DBus::ProxyFlags proxyFlags,
+        const std::string &name,
+        const std::string &objectPath,
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
+
     Glib::RefPtr<Gio::DBus::Proxy> dbusProxy() const { return m_proxy; }
 
     void TestCall(

--- a/tests/integration/proxy/testproxymain.cpp
+++ b/tests/integration/proxy/testproxymain.cpp
@@ -56,12 +56,11 @@ void on_test_uint_int_dict_finished(const Glib::RefPtr<Gio::AsyncResult> result,
     printStatus("UintIntDict", res == expectedMap);
 }
 
-void on_test_variant_finished(const Glib::RefPtr<Gio::AsyncResult> result, Glib::ustring expectedBase) {
+void on_test_variant_finished(const Glib::RefPtr<Gio::AsyncResult> result, Glib::Variant<Glib::ustring> expectedBase) {
     Glib::VariantBase base;
     proxy->TestVariant_finish(base, result);
 
-    // The proxy code has extracted the variant which should be a string so we can cast it now
-    std::string value;
+    Glib::ustring value;
     try {
         Glib::Variant<Glib::ustring> res = Glib::VariantBase::cast_dynamic< Glib::Variant<Glib::ustring> >(base);
         value = res.get();
@@ -69,14 +68,12 @@ void on_test_variant_finished(const Glib::RefPtr<Gio::AsyncResult> result, Glib:
         std::cout << e.what() << std::endl;
     }
 
-    std::string expectedValue = expectedBase;
-
-    printStatus("Variant", value == expectedValue);
+    printStatus("Variant", value == expectedBase.get());
 }
 
 void on_test_variant2_finished(const Glib::RefPtr<Gio::AsyncResult> result,
                                std::string expectedString,
-                               Glib::ustring expectedVariant)
+                               Glib::Variant<Glib::ustring> expectedVariant)
 {
     Glib::ustring string;
     Glib::VariantBase base;
@@ -91,7 +88,7 @@ void on_test_variant2_finished(const Glib::RefPtr<Gio::AsyncResult> result,
         std::cerr << e.what() << std::endl;
     }
 
-    printStatus("Variant2", string == expectedString && value == expectedVariant);
+    printStatus("Variant2", string == expectedString && value == expectedVariant.get());
 }
 
 void on_test_byte_string_array_finished (const Glib::RefPtr<Gio::AsyncResult> result, std::vector<std::string> expected) {
@@ -490,7 +487,7 @@ void proxy_created(const Glib::RefPtr<Gio::AsyncResult> result) {
         { 12, -384 },
         { 0, 1 },
     };
-    Glib::ustring variantValue = "string-as-variant";
+    Glib::Variant<Glib::ustring> variantValue = Glib::Variant<Glib::ustring>::create("string-as-variant");
 
     std::vector<std::string> inputStrVec;
     inputStrVec.push_back(__FUNCTION__);

--- a/tests/integration/stub/teststubmain.cpp
+++ b/tests/integration/stub/teststubmain.cpp
@@ -99,7 +99,18 @@ void TestImpl::TestVariant2(const Glib::ustring &Param1,
                             const Glib::VariantBase &Param2,
                             MethodInvocation invocation)
 {
-    invocation.ret(Param1, Param2);
+    std::string value;
+    try {
+        Glib::Variant<Glib::ustring> res = Glib::VariantBase::cast_dynamic< Glib::Variant<Glib::ustring> >(Param2);
+        value = res.get();
+    } catch (std::bad_cast e) {
+        std::cout << e.what() << std::endl;
+    }
+
+    Glib::Variant<Glib::Variant<Glib::ustring> > variantValue;
+    variantValue = Glib::Variant<Glib::Variant<Glib::ustring> >::create(Glib::Variant<Glib::ustring>::create(value));
+
+    invocation.ret(Param1, variantValue);
 }
 
 void TestImpl::TestByteStringArray (


### PR DESCRIPTION
Makes it much easier to write e.g. a cli tool where it does not matter if one blocks. See #65 for an example where three properties needs to be set.