### PR TITLE
setup.py: Rename the binary to gdbus-codegen-glibmm3

### DIFF
--- a/codegen_glibmm/__init__.py
+++ b/codegen_glibmm/__init__.py
@@ -22,7 +22,7 @@
 import os
 
 # Update this as the version changes
-version_info = (2, 0, 0)
+version_info = (2, 99, 0)
 version = '.'.join(str(c) for c in version_info)
 
 builddir = os.environ.get('UNINSTALLED_GLIB_BUILDDIR')

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     },
     entry_points = {
         'console_scripts': [
-            'gdbus-codegen-glibmm2 = codegen_glibmm.codegen_main:codegen_main',
+            'gdbus-codegen-glibmm3 = codegen_glibmm.codegen_main:codegen_main',
         ]
     }
  )


### PR DESCRIPTION
In order to allow coinstallation with the older versions, we need to
rename the installed script file and ensure that the installed python
module gets installed in its own directory. We achieve the latter by
changing the version number, since this affects the location where the
module files are installed.