### PR TITLE
README: Add clarification to description about generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/Pelagicore/gdbus-codegen-glibmm.svg?branch=master)](https://travis-ci.org/Pelagicore/gdbus-codegen-glibmm)
 
-This is a code generator for generating D-Bus stubs and proxies from XML
+This is a cpp code generator for generating D-Bus stubs and proxies from XML
 introspection files. The generated stubs and proxies are implemented using
 glibmm and giomm.
 


### PR DESCRIPTION
Add a small mention that the code generates cpp code. The aim is to meet expectation of  https://github.com/Pelagicore/gdbus-codegen-glibmm/issues/3