### PR TITLE
templates: Use references when passing around Glib::RefPtr

### DIFF
--- a/codegen_glibmm/templates/proxy.cpp.templ
+++ b/codegen_glibmm/templates/proxy.cpp.templ
@@ -221,7 +221,7 @@ void {{ class_name_with_namespace }}::createForBus(
         proxyFlags);
 }
 
-Glib::RefPtr<{{ class_name_with_namespace }}> {{ class_name_with_namespace }}::createForBusFinish(Glib::RefPtr<Gio::AsyncResult> result)
+Glib::RefPtr<{{ class_name_with_namespace }}> {{ class_name_with_namespace }}::createForBusFinish(const Glib::RefPtr<Gio::AsyncResult> &result)
 {
     Glib::RefPtr<Gio::DBus::Proxy> proxy =
         Gio::DBus::Proxy::create_for_bus_finish(result);

--- a/codegen_glibmm/templates/proxy.h.templ
+++ b/codegen_glibmm/templates/proxy.h.templ
@@ -21,7 +21,7 @@ public:
                              const Gio::SlotAsyncReady &slot,
                              const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
 
-    static Glib::RefPtr<{{ interface.cpp_class_name }}> createForBusFinish (Glib::RefPtr<Gio::AsyncResult> result);
+    static Glib::RefPtr<{{ interface.cpp_class_name }}> createForBusFinish (const Glib::RefPtr<Gio::AsyncResult> &result);
 
     static Glib::RefPtr<{{ interface.cpp_class_name }}> createForBus_sync(
         Gio::DBus::BusType busType,

--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -86,11 +86,12 @@ void {{ class_name_with_namespace }}::on_method_call(
         {{ arg.variant_type }} p_{{ arg.name }} = base_{{ arg.name }}.get();
 
     {% endfor %}
+        MethodInvocation methodInvocation(invocation);
         {{ method.name }}(
     {% for arg in method.in_args %}
             {{ arg.cpptype_get_cast }}(p_{{ arg.name }}),
     {% endfor %}
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
 {% endfor %}

--- a/codegen_glibmm/templates/stub.h.templ
+++ b/codegen_glibmm/templates/stub.h.templ
@@ -32,7 +32,7 @@ protected:
         {% for arg in method.in_args %}
         {{ arg.cpptype_in }} {{ arg.name }},
         {% endfor %}
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
 {% endfor %}
 {% for prop in interface.properties %}
 
@@ -96,7 +96,7 @@ private:
 
 class {{interface.cpp_class_name}}::MethodInvocation {
 public:
-    MethodInvocation(const Glib::RefPtr<Gio::DBus::MethodInvocation> msg):
+    MethodInvocation(const Glib::RefPtr<Gio::DBus::MethodInvocation> &msg):
         m_message(msg) {}
 
     const Glib::RefPtr<Gio::DBus::MethodInvocation> getMessage() {

--- a/tests/data/many-types/input_proxy.cpp
+++ b/tests/data/many-types/input_proxy.cpp
@@ -2883,7 +2883,7 @@ void org::gdbus::codegen::glibmm::Test::createForBus(
         proxyFlags);
 }
 
-Glib::RefPtr<org::gdbus::codegen::glibmm::Test> org::gdbus::codegen::glibmm::Test::createForBusFinish(Glib::RefPtr<Gio::AsyncResult> result)
+Glib::RefPtr<org::gdbus::codegen::glibmm::Test> org::gdbus::codegen::glibmm::Test::createForBusFinish(const Glib::RefPtr<Gio::AsyncResult> &result)
 {
     Glib::RefPtr<Gio::DBus::Proxy> proxy =
         Gio::DBus::Proxy::create_for_bus_finish(result);

--- a/tests/data/many-types/input_proxy.h
+++ b/tests/data/many-types/input_proxy.h
@@ -20,7 +20,7 @@ public:
                              const Gio::SlotAsyncReady &slot,
                              const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
 
-    static Glib::RefPtr<Test> createForBusFinish (Glib::RefPtr<Gio::AsyncResult> result);
+    static Glib::RefPtr<Test> createForBusFinish (const Glib::RefPtr<Gio::AsyncResult> &result);
 
     static Glib::RefPtr<Test> createForBus_sync(
         Gio::DBus::BusType busType,

--- a/tests/data/many-types/input_stub.cpp
+++ b/tests/data/many-types/input_stub.cpp
@@ -427,9 +427,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::map<Glib::ustring,Glib::VariantBase> p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestStringVariantDict(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestStringStringDict") == 0) {
@@ -437,9 +438,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::map<Glib::ustring,Glib::ustring> p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestStringStringDict(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestUintIntDict") == 0) {
@@ -447,9 +449,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::map<guint32,gint32> p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestUintIntDict(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestVariant") == 0) {
@@ -457,9 +460,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         Glib::VariantBase p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestVariant(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestVariant2") == 0) {
@@ -471,10 +475,11 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param2, 1);
         Glib::VariantBase p_Param2 = base_Param2.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestVariant2(
             (p_Param1),
             (p_Param2),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestByteStringArray") == 0) {
@@ -482,9 +487,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::vector<std::string> p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestByteStringArray(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestObjectPathArray") == 0) {
@@ -492,9 +498,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::vector<Glib::DBusObjectPathString> p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestObjectPathArray(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestStringArray") == 0) {
@@ -502,9 +509,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::vector<Glib::ustring> p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestStringArray(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestByteString") == 0) {
@@ -512,9 +520,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::string p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestByteString(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestStruct") == 0) {
@@ -522,9 +531,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::tuple<Glib::ustring,Glib::ustring> p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestStruct(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestStructArray") == 0) {
@@ -532,9 +542,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::vector<std::tuple<guint32,Glib::ustring,gint32>> p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestStructArray(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestDictStructArray") == 0) {
@@ -542,9 +553,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestDictStructArray(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestSignature") == 0) {
@@ -552,9 +564,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         Glib::DBusSignatureString p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestSignature(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestObjectPath") == 0) {
@@ -562,9 +575,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         Glib::DBusObjectPathString p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestObjectPath(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestString") == 0) {
@@ -572,9 +586,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         Glib::ustring p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestString(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestDouble") == 0) {
@@ -582,9 +597,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         double p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestDouble(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestUInt64") == 0) {
@@ -592,9 +608,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         guint64 p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestUInt64(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestInt64") == 0) {
@@ -602,9 +619,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         gint64 p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestInt64(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestUInt") == 0) {
@@ -612,9 +630,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         guint32 p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestUInt(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestInt") == 0) {
@@ -622,9 +641,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         gint32 p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestInt(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestUInt16") == 0) {
@@ -632,9 +652,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         guint16 p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestUInt16(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestInt16") == 0) {
@@ -642,9 +663,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         gint16 p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestInt16(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestChar") == 0) {
@@ -652,9 +674,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         guchar p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestChar(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestBoolean") == 0) {
@@ -662,9 +685,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param1, 0);
         bool p_Param1 = base_Param1.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestBoolean(
             (p_Param1),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestAll") == 0) {
@@ -732,6 +756,7 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_in_Param16, 15);
         bool p_in_Param16 = base_in_Param16.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestAll(
             (p_in_Param1),
             (p_in_Param2),
@@ -749,7 +774,7 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
             (p_in_Param14),
             (p_in_Param15),
             (p_in_Param16),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
     if (method_name.compare("TestTriggerInternalPropertyChange") == 0) {
@@ -757,9 +782,10 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_NewPropertyValue, 0);
         gint32 p_NewPropertyValue = base_NewPropertyValue.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestTriggerInternalPropertyChange(
             (p_NewPropertyValue),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
 }

--- a/tests/data/many-types/input_stub.h
+++ b/tests/data/many-types/input_stub.h
@@ -75,77 +75,77 @@ public:
 protected:
     virtual void TestStringVariantDict(
         const std::map<Glib::ustring,Glib::VariantBase> & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestStringStringDict(
         const std::map<Glib::ustring,Glib::ustring> & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestUintIntDict(
         const std::map<guint32,gint32> & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestVariant(
         const Glib::VariantBase & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestVariant2(
         const Glib::ustring & Param1,
         const Glib::VariantBase & Param2,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestByteStringArray(
         const std::vector<std::string> & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestObjectPathArray(
         const std::vector<Glib::DBusObjectPathString> & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestStringArray(
         const std::vector<Glib::ustring> & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestByteString(
         const std::string & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestStruct(
         const std::tuple<Glib::ustring,Glib::ustring> & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestStructArray(
         const std::vector<std::tuple<guint32,Glib::ustring,gint32>> & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestDictStructArray(
         const std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestSignature(
         const Glib::DBusSignatureString & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestObjectPath(
         const Glib::DBusObjectPathString & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestString(
         const Glib::ustring & Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestDouble(
         double Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestUInt64(
         guint64 Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestInt64(
         gint64 Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestUInt(
         guint32 Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestInt(
         gint32 Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestUInt16(
         guint16 Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestInt16(
         gint16 Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestChar(
         guchar Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestBoolean(
         bool Param1,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestAll(
         const std::vector<std::string> & in_Param1,
         const std::vector<Glib::DBusObjectPathString> & in_Param2,
@@ -163,10 +163,10 @@ protected:
         gint16 in_Param14,
         guchar in_Param15,
         bool in_Param16,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
     virtual void TestTriggerInternalPropertyChange(
         gint32 NewPropertyValue,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
 
     /* Handle the setting of a property
      * This method will be called as a result of a call to <PropName>_set
@@ -660,7 +660,7 @@ private:
 
 class Test::MethodInvocation {
 public:
-    MethodInvocation(const Glib::RefPtr<Gio::DBus::MethodInvocation> msg):
+    MethodInvocation(const Glib::RefPtr<Gio::DBus::MethodInvocation> &msg):
         m_message(msg) {}
 
     const Glib::RefPtr<Gio::DBus::MethodInvocation> getMessage() {

--- a/tests/data/simple/input_proxy.cpp
+++ b/tests/data/simple/input_proxy.cpp
@@ -142,7 +142,7 @@ void org::gdbus::codegen::glibmm::Test::createForBus(
         proxyFlags);
 }
 
-Glib::RefPtr<org::gdbus::codegen::glibmm::Test> org::gdbus::codegen::glibmm::Test::createForBusFinish(Glib::RefPtr<Gio::AsyncResult> result)
+Glib::RefPtr<org::gdbus::codegen::glibmm::Test> org::gdbus::codegen::glibmm::Test::createForBusFinish(const Glib::RefPtr<Gio::AsyncResult> &result)
 {
     Glib::RefPtr<Gio::DBus::Proxy> proxy =
         Gio::DBus::Proxy::create_for_bus_finish(result);

--- a/tests/data/simple/input_proxy.h
+++ b/tests/data/simple/input_proxy.h
@@ -20,7 +20,7 @@ public:
                              const Gio::SlotAsyncReady &slot,
                              const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
 
-    static Glib::RefPtr<Test> createForBusFinish (Glib::RefPtr<Gio::AsyncResult> result);
+    static Glib::RefPtr<Test> createForBusFinish (const Glib::RefPtr<Gio::AsyncResult> &result);
 
     static Glib::RefPtr<Test> createForBus_sync(
         Gio::DBus::BusType busType,

--- a/tests/data/simple/input_stub.cpp
+++ b/tests/data/simple/input_stub.cpp
@@ -110,10 +110,11 @@ void org::gdbus::codegen::glibmm::Test::on_method_call(
         parameters.get_child(base_Param2, 1);
         std::map<Glib::ustring,Glib::VariantBase> p_Param2 = base_Param2.get();
 
+        MethodInvocation methodInvocation(invocation);
         TestCall(
             (p_Param1),
             (p_Param2),
-            MethodInvocation(invocation));
+            methodInvocation);
     }
 
 }

--- a/tests/data/simple/input_stub.h
+++ b/tests/data/simple/input_stub.h
@@ -27,7 +27,7 @@ protected:
     virtual void TestCall(
         gint32 Param1,
         const std::map<Glib::ustring,Glib::VariantBase> & Param2,
-        MethodInvocation invocation) = 0;
+        MethodInvocation &invocation) = 0;
 
     /* Handle the setting of a property
      * This method will be called as a result of a call to <PropName>_set
@@ -84,7 +84,7 @@ private:
 
 class Test::MethodInvocation {
 public:
-    MethodInvocation(const Glib::RefPtr<Gio::DBus::MethodInvocation> msg):
+    MethodInvocation(const Glib::RefPtr<Gio::DBus::MethodInvocation> &msg):
         m_message(msg) {}
 
     const Glib::RefPtr<Gio::DBus::MethodInvocation> getMessage() {

--- a/tests/integration/stub/teststubmain.cpp
+++ b/tests/integration/stub/teststubmain.cpp
@@ -62,24 +62,24 @@ TestImpl::TestImpl() {
 }
 
 void TestImpl::TestStringVariantDict(const std::map<Glib::ustring,Glib::VariantBase> &Param1,
-                                     MethodInvocation invocation)
+                                     MethodInvocation &invocation)
 {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestStringStringDict(const std::map<Glib::ustring,Glib::ustring> &Param1,
-                                    MethodInvocation invocation)
+                                    MethodInvocation &invocation)
 {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestUintIntDict(const std::map<guint32,gint32> &Param1,
-                               MethodInvocation invocation)
+                               MethodInvocation &invocation)
 {
     invocation.ret(Param1);
 }
 
-void TestImpl::TestVariant(const Glib::VariantBase &Param1, MethodInvocation invocation)
+void TestImpl::TestVariant(const Glib::VariantBase &Param1, MethodInvocation &invocation)
 {
     std::string value;
     try {
@@ -97,7 +97,7 @@ void TestImpl::TestVariant(const Glib::VariantBase &Param1, MethodInvocation inv
 
 void TestImpl::TestVariant2(const Glib::ustring &Param1,
                             const Glib::VariantBase &Param2,
-                            MethodInvocation invocation)
+                            MethodInvocation &invocation)
 {
     std::string value;
     try {
@@ -115,115 +115,115 @@ void TestImpl::TestVariant2(const Glib::ustring &Param1,
 
 void TestImpl::TestByteStringArray (
         const std::vector<std::string> &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestObjectPathArray (
         const std::vector<Glib::DBusObjectPathString> &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestStringArray (
         const std::vector<Glib::ustring> &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestStruct(
         const std::tuple<Glib::ustring,Glib::ustring> &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestStructArray (
         const std::vector<std::tuple<guint32,Glib::ustring,gint32>> &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestDictStructArray (
         const std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestByteString (
         const std::string &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestSignature (
         const Glib::DBusSignatureString &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestObjectPath (
         const Glib::DBusObjectPathString &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestString (
         const Glib::ustring &Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestDouble (
         double Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestUInt64 (
         guint64 Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestInt64 (
         gint64 Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestUInt (
         guint32 Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestInt (
         gint32 Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestUInt16 (
         guint16 Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestInt16 (
         gint16 Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestChar (
         guchar Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
 void TestImpl::TestBoolean (
         bool Param1,
-        MethodInvocation invocation) {
+        MethodInvocation &invocation) {
     invocation.ret(Param1);
 }
 
@@ -244,16 +244,16 @@ void TestImpl::TestAll (
         gint16 in_Param14,
         guchar in_Param15,
         bool in_Param16,
-        MethodInvocation invocation) {}
+        MethodInvocation &invocation) {}
 
 void TestImpl::TestTriggerInternalPropertyChange(gint32 newValue,
-                                                 MethodInvocation invocation) {
+                                                 MethodInvocation &invocation) {
     TestPropInternalReadPropertyChange_set (newValue);
     TestPropInternalReadWritePropertyChange_set (newValue);
     invocation.ret();
 }
 
-void TestImpl::TestError(MethodInvocation invocation) {
+void TestImpl::TestError(MethodInvocation &invocation) {
     using namespace org::gdbus::codegen::glibmm;
     invocation.ret(Error(Error::InvalidParams, "Testing error message"));
 }

--- a/tests/integration/stub/teststubmain.h
+++ b/tests/integration/stub/teststubmain.h
@@ -6,76 +6,76 @@ public:
 
     void TestVariant (
             const Glib::VariantBase &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestVariant2(const Glib::ustring &Param1,
                       const Glib::VariantBase &Param2,
-                      MethodInvocation invocation) override;
+                      MethodInvocation &invocation) override;
     void TestStringVariantDict(
             const std::map<Glib::ustring,Glib::VariantBase> &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestStringStringDict(
             const std::map<Glib::ustring,Glib::ustring> &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestUintIntDict(
             const std::map<guint32,gint32> &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestByteStringArray (
             const std::vector<std::string> &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestObjectPathArray (
             const std::vector<Glib::DBusObjectPathString> &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestStringArray (
             const std::vector<Glib::ustring> &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestStruct(
             const std::tuple<Glib::ustring,Glib::ustring> &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestStructArray (
             const std::vector<std::tuple<guint32,Glib::ustring,gint32>> &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestDictStructArray (
             const std::vector<std::tuple<Glib::ustring,std::map<Glib::ustring,Glib::VariantBase>>> &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestByteString (
             const std::string &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestSignature (
             const Glib::DBusSignatureString &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestObjectPath (
             const Glib::DBusObjectPathString &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestString (
             const Glib::ustring &Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestDouble (
             double Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestUInt64 (
             guint64 Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestInt64 (
             gint64 Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestUInt (
             guint32 Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestInt (
             gint32 Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestUInt16 (
             guint16 Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestInt16 (
             gint16 Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestChar (
             guchar Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestBoolean (
             bool Param1,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestAll (
             const std::vector<std::string> &in_Param1,
             const std::vector<Glib::DBusObjectPathString> &in_Param2,
@@ -93,10 +93,10 @@ public:
             gint16 in_Param14,
             guchar in_Param15,
             bool in_Param16,
-            MethodInvocation invocation) override;
+            MethodInvocation &invocation) override;
     void TestTriggerInternalPropertyChange(gint32 newValue,
-                                           MethodInvocation invocation);
-    void TestError(MethodInvocation invocation) override;
+                                           MethodInvocation &invocation);
+    void TestError(MethodInvocation &invocation) override;
 
 
     std::vector<std::string>  TestPropReadByteStringArray_get();


### PR DESCRIPTION
To avoid unnecessary reference counting. MethodInvocation has a Glib::RefPtr member, so pass that as a reference as well.

Fixes #58.