### PR TITLE
Minor register object improvments and add registered_object() method

### DIFF
--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -32,6 +32,7 @@ guint {{ class_name_with_namespace }}::register_object(
         introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
     } catch(const Glib::Error& ex) {
         g_warning("Unable to create introspection data for %s: %s", object_path.c_str(), ex.what().c_str());
+        return 0;
     }
     Gio::DBus::InterfaceVTable *interface_vtable =
         new Gio::DBus::InterfaceVTable(

--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -23,7 +23,7 @@ guint {{ class_name_with_namespace }}::register_object(
     const Glib::RefPtr<Gio::DBus::Connection> &connection,
     const Glib::ustring &object_path)
 {
-    if (!m_objectPath.empty() && m_objectPath != object_path) {
+    if (m_registeredObjectId != 0) {
         g_warning("Cannot register the same object (%s) twice", object_path.c_str());
         return 0;
     }

--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -24,15 +24,14 @@ guint {{ class_name_with_namespace }}::register_object(
     const Glib::ustring &object_path)
 {
     if (!m_objectPath.empty() && m_objectPath != object_path) {
-        g_warning("Cannot register the same object twice!");
+        g_warning("Cannot register the same object (%s) twice", object_path.c_str());
         return 0;
     }
 
     try {
         introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
     } catch(const Glib::Error& ex) {
-        g_warning("Unable to create introspection data: ");
-        g_warning("%s\n", ex.what().c_str());
+        g_warning("Unable to create introspection data for %s: %s", object_path.c_str(), ex.what().c_str());
     }
     Gio::DBus::InterfaceVTable *interface_vtable =
         new Gio::DBus::InterfaceVTable(
@@ -47,7 +46,7 @@ guint {{ class_name_with_namespace }}::register_object(
         m_connection = connection;
         m_objectPath = object_path;
     } catch(const Glib::Error &ex) {
-        g_warning("Registration of object failed");
+        g_warning("Registration of object %s failed: %s", object_path.c_str(), ex.what().c_str());
     }
 
     return m_registeredObjectId;

--- a/codegen_glibmm/templates/stub.h.templ
+++ b/codegen_glibmm/templates/stub.h.templ
@@ -25,6 +25,10 @@ public:
                           const Glib::ustring &object_path);
     void unregister_object();
 
+    int usage_count() const {
+        return m_registeredObjectId == 0 ? 0 : 1;
+    }
+
     class MethodInvocation;
 
 {% for prop in interface.properties %}

--- a/tests/data/many-types/input_stub.cpp
+++ b/tests/data/many-types/input_stub.cpp
@@ -377,6 +377,7 @@ guint org::gdbus::codegen::glibmm::TestStub::register_object(
         introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
     } catch(const Glib::Error& ex) {
         g_warning("Unable to create introspection data for %s: %s", object_path.c_str(), ex.what().c_str());
+        return 0;
     }
     Gio::DBus::InterfaceVTable *interface_vtable =
         new Gio::DBus::InterfaceVTable(

--- a/tests/data/many-types/input_stub.cpp
+++ b/tests/data/many-types/input_stub.cpp
@@ -369,15 +369,14 @@ guint org::gdbus::codegen::glibmm::TestStub::register_object(
     const Glib::ustring &object_path)
 {
     if (!m_objectPath.empty() && m_objectPath != object_path) {
-        g_warning("Cannot register the same object twice!");
+        g_warning("Cannot register the same object (%s) twice", object_path.c_str());
         return 0;
     }
 
     try {
         introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
     } catch(const Glib::Error& ex) {
-        g_warning("Unable to create introspection data: ");
-        g_warning("%s\n", ex.what().c_str());
+        g_warning("Unable to create introspection data for %s: %s", object_path.c_str(), ex.what().c_str());
     }
     Gio::DBus::InterfaceVTable *interface_vtable =
         new Gio::DBus::InterfaceVTable(
@@ -392,7 +391,7 @@ guint org::gdbus::codegen::glibmm::TestStub::register_object(
         m_connection = connection;
         m_objectPath = object_path;
     } catch(const Glib::Error &ex) {
-        g_warning("Registration of object failed");
+        g_warning("Registration of object %s failed: %s", object_path.c_str(), ex.what().c_str());
     }
 
     return m_registeredObjectId;

--- a/tests/data/many-types/input_stub.cpp
+++ b/tests/data/many-types/input_stub.cpp
@@ -368,7 +368,7 @@ guint org::gdbus::codegen::glibmm::TestStub::register_object(
     const Glib::RefPtr<Gio::DBus::Connection> &connection,
     const Glib::ustring &object_path)
 {
-    if (!m_objectPath.empty() && m_objectPath != object_path) {
+    if (m_registeredObjectId != 0) {
         g_warning("Cannot register the same object (%s) twice", object_path.c_str());
         return 0;
     }

--- a/tests/data/many-types/input_stub.h
+++ b/tests/data/many-types/input_stub.h
@@ -24,6 +24,10 @@ public:
                           const Glib::ustring &object_path);
     void unregister_object();
 
+    int usage_count() const {
+        return m_registeredObjectId == 0 ? 0 : 1;
+    }
+
     class MethodInvocation;
 
     bool TestPropReadByteStringArray_set(const std::vector<std::string> & value);

--- a/tests/data/simple/input_stub.cpp
+++ b/tests/data/simple/input_stub.cpp
@@ -56,6 +56,7 @@ guint org::gdbus::codegen::glibmm::TestStub::register_object(
         introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
     } catch(const Glib::Error& ex) {
         g_warning("Unable to create introspection data for %s: %s", object_path.c_str(), ex.what().c_str());
+        return 0;
     }
     Gio::DBus::InterfaceVTable *interface_vtable =
         new Gio::DBus::InterfaceVTable(

--- a/tests/data/simple/input_stub.cpp
+++ b/tests/data/simple/input_stub.cpp
@@ -48,15 +48,14 @@ guint org::gdbus::codegen::glibmm::TestStub::register_object(
     const Glib::ustring &object_path)
 {
     if (!m_objectPath.empty() && m_objectPath != object_path) {
-        g_warning("Cannot register the same object twice!");
+        g_warning("Cannot register the same object (%s) twice", object_path.c_str());
         return 0;
     }
 
     try {
         introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
     } catch(const Glib::Error& ex) {
-        g_warning("Unable to create introspection data: ");
-        g_warning("%s\n", ex.what().c_str());
+        g_warning("Unable to create introspection data for %s: %s", object_path.c_str(), ex.what().c_str());
     }
     Gio::DBus::InterfaceVTable *interface_vtable =
         new Gio::DBus::InterfaceVTable(
@@ -71,7 +70,7 @@ guint org::gdbus::codegen::glibmm::TestStub::register_object(
         m_connection = connection;
         m_objectPath = object_path;
     } catch(const Glib::Error &ex) {
-        g_warning("Registration of object failed");
+        g_warning("Registration of object %s failed: %s", object_path.c_str(), ex.what().c_str());
     }
 
     return m_registeredObjectId;

--- a/tests/data/simple/input_stub.cpp
+++ b/tests/data/simple/input_stub.cpp
@@ -47,7 +47,7 @@ guint org::gdbus::codegen::glibmm::TestStub::register_object(
     const Glib::RefPtr<Gio::DBus::Connection> &connection,
     const Glib::ustring &object_path)
 {
-    if (!m_objectPath.empty() && m_objectPath != object_path) {
+    if (m_registeredObjectId != 0) {
         g_warning("Cannot register the same object (%s) twice", object_path.c_str());
         return 0;
     }

--- a/tests/data/simple/input_stub.h
+++ b/tests/data/simple/input_stub.h
@@ -24,6 +24,10 @@ public:
                           const Glib::ustring &object_path);
     void unregister_object();
 
+    int usage_count() const {
+        return m_registeredObjectId == 0 ? 0 : 1;
+    }
+
     class MethodInvocation;
 
     bool TestPropReadStringArray_set(const std::vector<Glib::ustring> & value);


### PR DESCRIPTION
Started out by simplifying some code in a service by adding a `bool registered_object() const` method to stub instead of storing state separately and mentioning object path in error messages (instead of logging it at call site on failure). Did some other minor fixes and cleanups as well that I happened to see when looking at `register_object()`. See commit log for details.

Originally split the "Improve logging" commit into multiple ones but decided to merge them. Can break them up again if wanted.