### PR TITLE
stub: Allow registering the same instance on multiple connections/paths

### DIFF
--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -23,45 +23,46 @@ guint {{ class_name_with_namespace }}::register_object(
     const Glib::RefPtr<Gio::DBus::Connection> &connection,
     const Glib::ustring &object_path)
 {
-    if (m_registeredObjectId != 0) {
-        g_warning("Cannot register the same object (%s) twice", object_path.c_str());
-        return 0;
+    if (!introspection_data) {
+        try {
+            introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
+        } catch(const Glib::Error& ex) {
+            g_warning("Unable to create introspection data for %s: %s", object_path.c_str(), ex.what().c_str());
+            return 0;
+        }
     }
 
-    try {
-        introspection_data = Gio::DBus::NodeInfo::create_for_xml(interfaceXml0);
-    } catch(const Glib::Error& ex) {
-        g_warning("Unable to create introspection data for %s: %s", object_path.c_str(), ex.what().c_str());
-        return 0;
-    }
     Gio::DBus::InterfaceVTable *interface_vtable =
         new Gio::DBus::InterfaceVTable(
             sigc::mem_fun(this, &{{ interface.cpp_class_name_stub }}::on_method_call),
             sigc::mem_fun(this, &{{ interface.cpp_class_name_stub }}::on_interface_get_property),
             sigc::mem_fun(this, &{{ interface.cpp_class_name_stub }}::on_interface_set_property));
 
+    guint registration_id;
     try {
-        m_registeredObjectId = connection->register_object(object_path,
+        registration_id = connection->register_object(object_path,
             introspection_data->lookup_interface("{{ interface.name }}"),
             *interface_vtable);
-        m_connection = connection;
-        m_objectPath = object_path;
     } catch(const Glib::Error &ex) {
         g_warning("Registration of object %s failed: %s", object_path.c_str(), ex.what().c_str());
+        return 0;
     }
 
-    return m_registeredObjectId;
+    m_registered_objects.emplace_back(RegisteredObject {
+        registration_id,
+        connection,
+        object_path
+    });
+
+    return registration_id;
 }
 
 void {{ class_name_with_namespace }}::unregister_object()
 {
-    if (m_registeredObjectId == 0)
-        return;
-
-    m_connection->unregister_object(m_registeredObjectId);
-    m_registeredObjectId = 0;
-    m_connection.reset();
-    m_objectPath.clear();
+    for (const RegisteredObject &obj: m_registered_objects) {
+        obj.connection->unregister_object(obj.id);
+    }
+    m_registered_objects.clear();
 }
 
 void {{ class_name_with_namespace }}::on_method_call(
@@ -156,12 +157,16 @@ void {{ class_name_with_namespace }}::{{ signal.name }}_emitter(
     paramsList.push_back(Glib::Variant<{{ arg.variant_type }}>::create({{ arg.cpptype_to_dbus }}({{ arg.name }})));;
 {% endfor %}
 
-    m_connection->emit_signal(
-        m_objectPath,
-        "{{ signal.iface_name }}",
-        "{{ signal.name }}",
-        Glib::ustring(),
-        Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList));
+    const Glib::VariantContainerBase params =
+        Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
+    for (const RegisteredObject &obj: m_registered_objects) {
+        obj.connection->emit_signal(
+            obj.object_path,
+            "{{ signal.iface_name }}",
+            "{{ signal.name }}",
+            Glib::ustring(),
+            params);
+    }
 }
 
 {% endfor %}
@@ -200,12 +205,14 @@ bool {{ class_name_with_namespace }}::emitSignal(
     Glib::VariantContainerBase propertiesChangedVariant =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(ps);
 
-    m_connection->emit_signal(
-        m_objectPath,
-        "org.freedesktop.DBus.Properties",
-        "PropertiesChanged",
-        Glib::ustring(),
-        propertiesChangedVariant);
+    for (const RegisteredObject &obj: m_registered_objects) {
+        obj.connection->emit_signal(
+            obj.object_path,
+            "org.freedesktop.DBus.Properties",
+            "PropertiesChanged",
+            Glib::ustring(),
+            propertiesChangedVariant);
+    }
 
     return true;
 }

--- a/codegen_glibmm/templates/stub.h.templ
+++ b/codegen_glibmm/templates/stub.h.templ
@@ -25,8 +25,8 @@ public:
                           const Glib::ustring &object_path);
     void unregister_object();
 
-    int usage_count() const {
-        return m_registeredObjectId == 0 ? 0 : 1;
+    unsigned int usage_count() const {
+        return static_cast<unsigned int>(m_registered_objects.size());
     }
 
     class MethodInvocation;
@@ -86,10 +86,14 @@ protected:
 private:
     bool emitSignal(const std::string &propName, Glib::VariantBase &value);
 
+    struct RegisteredObject {
+        guint id;
+        Glib::RefPtr<Gio::DBus::Connection> connection;
+        std::string object_path;
+    };
+
     Glib::RefPtr<Gio::DBus::NodeInfo> introspection_data;
-    Glib::RefPtr<Gio::DBus::Connection> m_connection;
-    guint m_registeredObjectId = 0;
-    std::string m_objectPath;
+    std::vector<RegisteredObject> m_registered_objects;
     std::string m_interfaceName;
 };
 

--- a/tests/data/many-types/input_stub.h
+++ b/tests/data/many-types/input_stub.h
@@ -24,8 +24,8 @@ public:
                           const Glib::ustring &object_path);
     void unregister_object();
 
-    int usage_count() const {
-        return m_registeredObjectId == 0 ? 0 : 1;
+    unsigned int usage_count() const {
+        return static_cast<unsigned int>(m_registered_objects.size());
     }
 
     class MethodInvocation;
@@ -650,10 +650,14 @@ protected:
 private:
     bool emitSignal(const std::string &propName, Glib::VariantBase &value);
 
+    struct RegisteredObject {
+        guint id;
+        Glib::RefPtr<Gio::DBus::Connection> connection;
+        std::string object_path;
+    };
+
     Glib::RefPtr<Gio::DBus::NodeInfo> introspection_data;
-    Glib::RefPtr<Gio::DBus::Connection> m_connection;
-    guint m_registeredObjectId = 0;
-    std::string m_objectPath;
+    std::vector<RegisteredObject> m_registered_objects;
     std::string m_interfaceName;
 };
 

--- a/tests/data/simple/input_stub.h
+++ b/tests/data/simple/input_stub.h
@@ -24,8 +24,8 @@ public:
                           const Glib::ustring &object_path);
     void unregister_object();
 
-    int usage_count() const {
-        return m_registeredObjectId == 0 ? 0 : 1;
+    unsigned int usage_count() const {
+        return static_cast<unsigned int>(m_registered_objects.size());
     }
 
     class MethodInvocation;
@@ -74,10 +74,14 @@ protected:
 private:
     bool emitSignal(const std::string &propName, Glib::VariantBase &value);
 
+    struct RegisteredObject {
+        guint id;
+        Glib::RefPtr<Gio::DBus::Connection> connection;
+        std::string object_path;
+    };
+
     Glib::RefPtr<Gio::DBus::NodeInfo> introspection_data;
-    Glib::RefPtr<Gio::DBus::Connection> m_connection;
-    guint m_registeredObjectId = 0;
-    std::string m_objectPath;
+    std::vector<RegisteredObject> m_registered_objects;
     std::string m_interfaceName;
 };
 


### PR DESCRIPTION
(This is a WIP, as new tests for this feature are missing, and old tests are failing; I'll fix this once the code has been reviewed, to avoid updating the templates every time :-) )

Stubs can be registered on multiple connections, and also multiple times
on the same connection, as long as object paths are different. This
commit enables this, by turning the object registration data into an
array.

Note that signals need to be emitted on each connection/path.

A check to avoid duplicate registrations (with the same connection/path)
is not needed, as it's already performed by
g_dbus_connection_register_object().

Fixes: #81

Signed-off-by: Alberto Mardegan <amardegan@luxoft.com>