### PR TITLE
Add methods to create proxy on arbitrary connections

### DIFF
--- a/codegen_glibmm/templates/proxy.cpp.templ
+++ b/codegen_glibmm/templates/proxy.cpp.templ
@@ -210,6 +210,53 @@ void {{ class_name_with_namespace }}::handle_properties_changed(
 {% endif %}
 }
 
+void {{ class_name_with_namespace }}::create(
+    const Glib::RefPtr<Gio::DBus::Connection> &connection,
+    Gio::DBus::ProxyFlags proxyFlags,
+    const std::string &name,
+    const std::string &objectPath,
+    const Gio::SlotAsyncReady &slot,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+{
+    Gio::DBus::Proxy::create(connection,
+        name,
+        objectPath,
+        "{{ interface.name }}",
+        slot,
+        cancellable,
+        Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+        proxyFlags);
+}
+
+Glib::RefPtr<{{ class_name_with_namespace }}> {{ class_name_with_namespace }}::createFinish(const Glib::RefPtr<Gio::AsyncResult> &result)
+{
+    Glib::RefPtr<Gio::DBus::Proxy> proxy =
+        Gio::DBus::Proxy::create_finish(result);
+    {{ class_name_with_namespace }} *p =
+        new {{ class_name_with_namespace }}(proxy);
+    return Glib::RefPtr<{{ class_name_with_namespace }}>(p);
+}
+
+Glib::RefPtr<{{ class_name_with_namespace }}> {{ class_name_with_namespace }}::create_sync(
+    const Glib::RefPtr<Gio::DBus::Connection> &connection,
+    Gio::DBus::ProxyFlags proxyFlags,
+    const std::string &name,
+    const std::string &objectPath,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+{
+    Glib::RefPtr<Gio::DBus::Proxy> proxy =
+        Gio::DBus::Proxy::create_sync(connection,
+            name,
+            objectPath,
+            "{{ interface.name }}",
+            cancellable,
+            Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+            proxyFlags);
+    {{ class_name_with_namespace }} *p =
+        new {{ class_name_with_namespace }}(proxy);
+    return Glib::RefPtr<{{ class_name_with_namespace }}>(p);
+}
+
 void {{ class_name_with_namespace }}::createForBus(
     Gio::DBus::BusType busType,
     Gio::DBus::ProxyFlags proxyFlags,

--- a/codegen_glibmm/templates/proxy.h.templ
+++ b/codegen_glibmm/templates/proxy.h.templ
@@ -14,6 +14,12 @@ namespace {{ namespace }} {
 
 class {{ interface.cpp_class_name_proxy }} : public Glib::ObjectBase {
 public:
+    static void create(const Glib::RefPtr<Gio::DBus::Connection> &connection,
+                       Gio::DBus::ProxyFlags proxyFlags,
+                       const std::string &name,
+                       const std::string &objectPath,
+                       const Gio::SlotAsyncReady &slot,
+                       const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
     static void createForBus(Gio::DBus::BusType busType,
                              Gio::DBus::ProxyFlags proxyFlags,
                              const std::string &name,
@@ -21,8 +27,15 @@ public:
                              const Gio::SlotAsyncReady &slot,
                              const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
 
-    static Glib::RefPtr<{{ interface.cpp_class_name_proxy }}> createForBusFinish (const Glib::RefPtr<Gio::AsyncResult> &result);
+    static Glib::RefPtr<{{ interface.cpp_class_name_proxy }}> createFinish(const Glib::RefPtr<Gio::AsyncResult> &result);
+    static Glib::RefPtr<{{ interface.cpp_class_name_proxy }}> create_sync(
+        const Glib::RefPtr<Gio::DBus::Connection> &connection,
+        Gio::DBus::ProxyFlags proxyFlags,
+        const std::string &name,
+        const std::string &objectPath,
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
 
+    static Glib::RefPtr<{{ interface.cpp_class_name_proxy }}> createForBusFinish (const Glib::RefPtr<Gio::AsyncResult> &result);
     static Glib::RefPtr<{{ interface.cpp_class_name_proxy }}> createForBus_sync(
         Gio::DBus::BusType busType,
         Gio::DBus::ProxyFlags proxyFlags,

--- a/tests/data/many-types/input_proxy.cpp
+++ b/tests/data/many-types/input_proxy.cpp
@@ -3102,6 +3102,53 @@ org::gdbus::codegen::glibmm::TestProxy::TestProxy(const Glib::RefPtr<Gio::DBus::
         connect(sigc::mem_fun(this, &TestProxy::handle_properties_changed));
 }
 
+void org::gdbus::codegen::glibmm::TestProxy::create(
+    const Glib::RefPtr<Gio::DBus::Connection> &connection,
+    Gio::DBus::ProxyFlags proxyFlags,
+    const std::string &name,
+    const std::string &objectPath,
+    const Gio::SlotAsyncReady &slot,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+{
+    Gio::DBus::Proxy::create(connection,
+        name,
+        objectPath,
+        "org.gdbus.codegen.glibmm.Test",
+        slot,
+        cancellable,
+        Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+        proxyFlags);
+}
+
+Glib::RefPtr<org::gdbus::codegen::glibmm::TestProxy> org::gdbus::codegen::glibmm::TestProxy::createFinish(const Glib::RefPtr<Gio::AsyncResult> &result)
+{
+    Glib::RefPtr<Gio::DBus::Proxy> proxy =
+        Gio::DBus::Proxy::create_finish(result);
+    org::gdbus::codegen::glibmm::TestProxy *p =
+        new org::gdbus::codegen::glibmm::TestProxy(proxy);
+    return Glib::RefPtr<org::gdbus::codegen::glibmm::TestProxy>(p);
+}
+
+Glib::RefPtr<org::gdbus::codegen::glibmm::TestProxy> org::gdbus::codegen::glibmm::TestProxy::create_sync(
+    const Glib::RefPtr<Gio::DBus::Connection> &connection,
+    Gio::DBus::ProxyFlags proxyFlags,
+    const std::string &name,
+    const std::string &objectPath,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+{
+    Glib::RefPtr<Gio::DBus::Proxy> proxy =
+        Gio::DBus::Proxy::create_sync(connection,
+            name,
+            objectPath,
+            "org.gdbus.codegen.glibmm.Test",
+            cancellable,
+            Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+            proxyFlags);
+    org::gdbus::codegen::glibmm::TestProxy *p =
+        new org::gdbus::codegen::glibmm::TestProxy(proxy);
+    return Glib::RefPtr<org::gdbus::codegen::glibmm::TestProxy>(p);
+}
+
 void org::gdbus::codegen::glibmm::TestProxy::createForBus(
     Gio::DBus::BusType busType,
     Gio::DBus::ProxyFlags proxyFlags,

--- a/tests/data/many-types/input_proxy.h
+++ b/tests/data/many-types/input_proxy.h
@@ -13,6 +13,12 @@ namespace glibmm {
 
 class TestProxy : public Glib::ObjectBase {
 public:
+    static void create(const Glib::RefPtr<Gio::DBus::Connection> &connection,
+                       Gio::DBus::ProxyFlags proxyFlags,
+                       const std::string &name,
+                       const std::string &objectPath,
+                       const Gio::SlotAsyncReady &slot,
+                       const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
     static void createForBus(Gio::DBus::BusType busType,
                              Gio::DBus::ProxyFlags proxyFlags,
                              const std::string &name,
@@ -20,8 +26,15 @@ public:
                              const Gio::SlotAsyncReady &slot,
                              const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
 
-    static Glib::RefPtr<TestProxy> createForBusFinish (const Glib::RefPtr<Gio::AsyncResult> &result);
+    static Glib::RefPtr<TestProxy> createFinish(const Glib::RefPtr<Gio::AsyncResult> &result);
+    static Glib::RefPtr<TestProxy> create_sync(
+        const Glib::RefPtr<Gio::DBus::Connection> &connection,
+        Gio::DBus::ProxyFlags proxyFlags,
+        const std::string &name,
+        const std::string &objectPath,
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
 
+    static Glib::RefPtr<TestProxy> createForBusFinish (const Glib::RefPtr<Gio::AsyncResult> &result);
     static Glib::RefPtr<TestProxy> createForBus_sync(
         Gio::DBus::BusType busType,
         Gio::DBus::ProxyFlags proxyFlags,

--- a/tests/data/simple/input_proxy.cpp
+++ b/tests/data/simple/input_proxy.cpp
@@ -130,6 +130,53 @@ org::gdbus::codegen::glibmm::TestProxy::TestProxy(const Glib::RefPtr<Gio::DBus::
     org::gdbus::codegen::glibmm::Error::initialize();
 }
 
+void org::gdbus::codegen::glibmm::TestProxy::create(
+    const Glib::RefPtr<Gio::DBus::Connection> &connection,
+    Gio::DBus::ProxyFlags proxyFlags,
+    const std::string &name,
+    const std::string &objectPath,
+    const Gio::SlotAsyncReady &slot,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+{
+    Gio::DBus::Proxy::create(connection,
+        name,
+        objectPath,
+        "org.gdbus.codegen.glibmm.Test",
+        slot,
+        cancellable,
+        Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+        proxyFlags);
+}
+
+Glib::RefPtr<org::gdbus::codegen::glibmm::TestProxy> org::gdbus::codegen::glibmm::TestProxy::createFinish(const Glib::RefPtr<Gio::AsyncResult> &result)
+{
+    Glib::RefPtr<Gio::DBus::Proxy> proxy =
+        Gio::DBus::Proxy::create_finish(result);
+    org::gdbus::codegen::glibmm::TestProxy *p =
+        new org::gdbus::codegen::glibmm::TestProxy(proxy);
+    return Glib::RefPtr<org::gdbus::codegen::glibmm::TestProxy>(p);
+}
+
+Glib::RefPtr<org::gdbus::codegen::glibmm::TestProxy> org::gdbus::codegen::glibmm::TestProxy::create_sync(
+    const Glib::RefPtr<Gio::DBus::Connection> &connection,
+    Gio::DBus::ProxyFlags proxyFlags,
+    const std::string &name,
+    const std::string &objectPath,
+    const Glib::RefPtr<Gio::Cancellable> &cancellable)
+{
+    Glib::RefPtr<Gio::DBus::Proxy> proxy =
+        Gio::DBus::Proxy::create_sync(connection,
+            name,
+            objectPath,
+            "org.gdbus.codegen.glibmm.Test",
+            cancellable,
+            Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+            proxyFlags);
+    org::gdbus::codegen::glibmm::TestProxy *p =
+        new org::gdbus::codegen::glibmm::TestProxy(proxy);
+    return Glib::RefPtr<org::gdbus::codegen::glibmm::TestProxy>(p);
+}
+
 void org::gdbus::codegen::glibmm::TestProxy::createForBus(
     Gio::DBus::BusType busType,
     Gio::DBus::ProxyFlags proxyFlags,

--- a/tests/data/simple/input_proxy.h
+++ b/tests/data/simple/input_proxy.h
@@ -13,6 +13,12 @@ namespace glibmm {
 
 class TestProxy : public Glib::ObjectBase {
 public:
+    static void create(const Glib::RefPtr<Gio::DBus::Connection> &connection,
+                       Gio::DBus::ProxyFlags proxyFlags,
+                       const std::string &name,
+                       const std::string &objectPath,
+                       const Gio::SlotAsyncReady &slot,
+                       const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
     static void createForBus(Gio::DBus::BusType busType,
                              Gio::DBus::ProxyFlags proxyFlags,
                              const std::string &name,
@@ -20,8 +26,15 @@ public:
                              const Gio::SlotAsyncReady &slot,
                              const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
 
-    static Glib::RefPtr<TestProxy> createForBusFinish (const Glib::RefPtr<Gio::AsyncResult> &result);
+    static Glib::RefPtr<TestProxy> createFinish(const Glib::RefPtr<Gio::AsyncResult> &result);
+    static Glib::RefPtr<TestProxy> create_sync(
+        const Glib::RefPtr<Gio::DBus::Connection> &connection,
+        Gio::DBus::ProxyFlags proxyFlags,
+        const std::string &name,
+        const std::string &objectPath,
+        const Glib::RefPtr<Gio::Cancellable> &cancellable = {});
 
+    static Glib::RefPtr<TestProxy> createForBusFinish (const Glib::RefPtr<Gio::AsyncResult> &result);
     static Glib::RefPtr<TestProxy> createForBus_sync(
         Gio::DBus::BusType busType,
         Gio::DBus::ProxyFlags proxyFlags,


### PR DESCRIPTION
This allows, for example, the creation of a peer to peer D-Bus connection over a socket.