### PR TITLE
Add selective signal method to support multicast

### DIFF
--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -182,7 +182,7 @@ void {{ class_name_with_namespace }}::{{ signal.name }}_emitter(
     const std::vector<Glib::ustring> &destination_bus_names,
 {%- set comma = joiner() -%}
 {%- for arg in signal.args -%}
-{{ comma() }}{{ arg.cpptype_out }} {{ arg.name }}
+{{ comma() }}{{ arg.cpptype_in }} {{ arg.name }}
 {%- endfor -%})
 {
     std::vector<Glib::VariantBase> paramsList;

--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -27,7 +27,9 @@ inline std::string specialGetter(Glib::Variant<std::string> variant)
     m_interfaceName("{{ interface.name }}")
 {
 {% for signal in interface.signals if signal is supported_by_sigc %}
-    {{ signal.name }}_signal.connect(sigc::mem_fun(this, &{{ interface.cpp_class_name_stub }}::{{ signal.name }}_emitter));
+    {{ signal.name }}_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &{{ interface.cpp_class_name_stub }}::{{ signal.name }}_emitter),
+            std::vector<Glib::ustring>({""})) );
+    {{ signal.name }}_selectiveSignal.connect(sigc::mem_fun(this, &{{ interface.cpp_class_name_stub }}::{{ signal.name }}_emitter));
 {% endfor %}
 }
 
@@ -177,6 +179,7 @@ bool {{ class_name_with_namespace }}::on_interface_set_property(
 
 {% for signal in interface.signals if signal is supported_by_sigc %}
 void {{ class_name_with_namespace }}::{{ signal.name }}_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,
 {%- set comma = joiner() -%}
 {%- for arg in signal.args -%}
 {{ comma() }}{{ arg.cpptype_out }} {{ arg.name }}
@@ -191,12 +194,14 @@ void {{ class_name_with_namespace }}::{{ signal.name }}_emitter(
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "{{ signal.iface_name }}",
-            "{{ signal.name }}",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "{{ signal.iface_name }}",
+                    "{{ signal.name }}",
+                    bus_name,
+                    params);
+        }
     }
 }
 

--- a/codegen_glibmm/templates/stub.h.templ
+++ b/codegen_glibmm/templates/stub.h.templ
@@ -55,8 +55,9 @@ protected:
 {% for signal in interface.signals %}
 {% if signal is supported_by_sigc %}
 
-    void {{ signal.name }}_emitter({{ signal.args|map(attribute='cpptype_out')|join(', ') }});
+    void {{ signal.name }}_emitter(const std::vector<Glib::ustring> &destination_bus_names, {{ signal.args|map(attribute='cpptype_out')|join(', ') }});
     sigc::signal<void, {{ signal.args|map(attribute='cpptype_out')|join(', ') }}> {{ signal.name }}_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, {{ signal.args|map(attribute='cpptype_out')|join(', ') }}> {{ signal.name }}_selectiveSignal;
 {% endif %}
 {% endfor %}
 

--- a/codegen_glibmm/templates/stub.h.templ
+++ b/codegen_glibmm/templates/stub.h.templ
@@ -55,9 +55,9 @@ protected:
 {% for signal in interface.signals %}
 {% if signal is supported_by_sigc %}
 
-    void {{ signal.name }}_emitter(const std::vector<Glib::ustring> &destination_bus_names, {{ signal.args|map(attribute='cpptype_out')|join(', ') }});
-    sigc::signal<void, {{ signal.args|map(attribute='cpptype_out')|join(', ') }}> {{ signal.name }}_signal;
-    sigc::signal<void, const std::vector<Glib::ustring>&, {{ signal.args|map(attribute='cpptype_out')|join(', ') }}> {{ signal.name }}_selectiveSignal;
+    void {{ signal.name }}_emitter(const std::vector<Glib::ustring> &destination_bus_names, {{ signal.args|map(attribute='cpptype_in')|join(', ') }});
+    sigc::signal<void, {{ signal.args|map(attribute='cpptype_in')|join(', ') }}> {{ signal.name }}_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, {{ signal.args|map(attribute='cpptype_in')|join(', ') }}> {{ signal.name }}_selectiveSignal;
 {% endif %}
 {% endfor %}
 

--- a/tests/data/many-types/input_stub.cpp
+++ b/tests/data/many-types/input_stub.cpp
@@ -358,22 +358,54 @@ inline std::string specialGetter(Glib::Variant<std::string> variant)
 org::gdbus::codegen::glibmm::TestStub::TestStub():
     m_interfaceName("org.gdbus.codegen.glibmm.Test")
 {
-    TestSignalByteStringArray_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalByteStringArray_emitter));
-    TestSignalObjectPathArray_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter));
-    TestSignalStringArray_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalStringArray_emitter));
-    TestSignalByteString_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalByteString_emitter));
-    TestSignalSignature_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalSignature_emitter));
-    TestSignalObjectPath_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalObjectPath_emitter));
-    TestSignalString_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalString_emitter));
-    TestSignalDouble_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalDouble_emitter));
-    TestSignalUInt64_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalUInt64_emitter));
-    TestSignalInt64_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalInt64_emitter));
-    TestSignalUInt_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalUInt_emitter));
-    TestSignalInt_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalInt_emitter));
-    TestSignalUInt16_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalUInt16_emitter));
-    TestSignalInt16_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalInt16_emitter));
-    TestSignalChar_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalChar_emitter));
-    TestSignalBoolean_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalBoolean_emitter));
+TestSignalByteStringArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalByteStringArray_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalByteStringArray_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalByteStringArray_emitter));
+TestSignalObjectPathArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalObjectPathArray_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter));
+TestSignalStringArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalStringArray_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalStringArray_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalStringArray_emitter));
+TestSignalByteString_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalByteString_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalByteString_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalByteString_emitter));
+TestSignalSignature_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalSignature_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalSignature_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalSignature_emitter));
+TestSignalObjectPath_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalObjectPath_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalObjectPath_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalObjectPath_emitter));
+TestSignalString_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalString_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalString_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalString_emitter));
+TestSignalDouble_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalDouble_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalDouble_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalDouble_emitter));
+TestSignalUInt64_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalUInt64_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalUInt64_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalUInt64_emitter));
+TestSignalInt64_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalInt64_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalInt64_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalInt64_emitter));
+TestSignalUInt_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalUInt_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalUInt_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalUInt_emitter));
+TestSignalInt_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalInt_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalInt_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalInt_emitter));
+TestSignalUInt16_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalUInt16_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalUInt16_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalUInt16_emitter));
+TestSignalInt16_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalInt16_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalInt16_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalInt16_emitter));
+TestSignalChar_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalChar_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalChar_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalChar_emitter));
+TestSignalBoolean_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalBoolean_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalBoolean_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalBoolean_emitter));
 }
 
 org::gdbus::codegen::glibmm::TestStub::~TestStub()
@@ -1419,7 +1451,8 @@ bool org::gdbus::codegen::glibmm::TestStub::on_interface_set_property(
     return true;
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalByteStringArray_emitter(std::vector<std::string> Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalByteStringArray_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,std::vector<std::string> Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1428,16 +1461,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalByteStringArray_emitter(st
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalByteStringArray",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalByteStringArray",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(std::vector<Glib::DBusObjectPathString> Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,std::vector<Glib::DBusObjectPathString> Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1446,16 +1482,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(st
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalObjectPathArray",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalObjectPathArray",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalStringArray_emitter(std::vector<Glib::ustring> Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalStringArray_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,std::vector<Glib::ustring> Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1464,16 +1503,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalStringArray_emitter(std::v
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalStringArray",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalStringArray",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalByteString_emitter(std::string Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalByteString_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,std::string Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1482,16 +1524,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalByteString_emitter(std::st
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalByteString",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalByteString",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalSignature_emitter(Glib::DBusSignatureString Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalSignature_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,Glib::DBusSignatureString Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1500,16 +1545,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalSignature_emitter(Glib::DB
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalSignature",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalSignature",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPath_emitter(Glib::DBusObjectPathString Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPath_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,Glib::DBusObjectPathString Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1518,16 +1566,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPath_emitter(Glib::D
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalObjectPath",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalObjectPath",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalString_emitter(Glib::ustring Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalString_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,Glib::ustring Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1536,16 +1587,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalString_emitter(Glib::ustri
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalString",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalString",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalDouble_emitter(double Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalDouble_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,double Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1554,16 +1608,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalDouble_emitter(double Para
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalDouble",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalDouble",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalUInt64_emitter(guint64 Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalUInt64_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,guint64 Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1572,16 +1629,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalUInt64_emitter(guint64 Par
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalUInt64",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalUInt64",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalInt64_emitter(gint64 Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalInt64_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,gint64 Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1590,16 +1650,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalInt64_emitter(gint64 Param
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalInt64",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalInt64",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalUInt_emitter(guint32 Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalUInt_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,guint32 Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1608,16 +1671,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalUInt_emitter(guint32 Param
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalUInt",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalUInt",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalInt_emitter(gint32 Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalInt_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,gint32 Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1626,16 +1692,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalInt_emitter(gint32 Param1)
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalInt",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalInt",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalUInt16_emitter(guint16 Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalUInt16_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,guint16 Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1644,16 +1713,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalUInt16_emitter(guint16 Par
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalUInt16",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalUInt16",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalInt16_emitter(gint16 Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalInt16_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,gint16 Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1662,16 +1734,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalInt16_emitter(gint16 Param
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalInt16",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalInt16",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalChar_emitter(guchar Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalChar_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,guchar Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1680,16 +1755,19 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalChar_emitter(guchar Param1
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalChar",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalChar",
+                    bus_name,
+                    params);
+        }
     }
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalBoolean_emitter(bool Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalBoolean_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,bool Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1698,14 +1776,17 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalBoolean_emitter(bool Param
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalBoolean",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalBoolean",
+                    bus_name,
+                    params);
+        }
     }
 }
+
 
 
 bool org::gdbus::codegen::glibmm::TestStub::TestPropReadByteStringArray_set(const std::vector<std::string> & value)

--- a/tests/data/many-types/input_stub.cpp
+++ b/tests/data/many-types/input_stub.cpp
@@ -358,52 +358,52 @@ inline std::string specialGetter(Glib::Variant<std::string> variant)
 org::gdbus::codegen::glibmm::TestStub::TestStub():
     m_interfaceName("org.gdbus.codegen.glibmm.Test")
 {
-TestSignalByteStringArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalByteStringArray_emitter),
+    TestSignalByteStringArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalByteStringArray_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalByteStringArray_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalByteStringArray_emitter));
-TestSignalObjectPathArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter),
+    TestSignalObjectPathArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalObjectPathArray_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter));
-TestSignalStringArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalStringArray_emitter),
+    TestSignalStringArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalStringArray_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalStringArray_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalStringArray_emitter));
-TestSignalByteString_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalByteString_emitter),
+    TestSignalByteString_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalByteString_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalByteString_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalByteString_emitter));
-TestSignalSignature_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalSignature_emitter),
+    TestSignalSignature_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalSignature_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalSignature_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalSignature_emitter));
-TestSignalObjectPath_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalObjectPath_emitter),
+    TestSignalObjectPath_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalObjectPath_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalObjectPath_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalObjectPath_emitter));
-TestSignalString_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalString_emitter),
+    TestSignalString_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalString_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalString_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalString_emitter));
-TestSignalDouble_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalDouble_emitter),
+    TestSignalDouble_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalDouble_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalDouble_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalDouble_emitter));
-TestSignalUInt64_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalUInt64_emitter),
+    TestSignalUInt64_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalUInt64_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalUInt64_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalUInt64_emitter));
-TestSignalInt64_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalInt64_emitter),
+    TestSignalInt64_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalInt64_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalInt64_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalInt64_emitter));
-TestSignalUInt_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalUInt_emitter),
+    TestSignalUInt_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalUInt_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalUInt_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalUInt_emitter));
-TestSignalInt_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalInt_emitter),
+    TestSignalInt_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalInt_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalInt_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalInt_emitter));
-TestSignalUInt16_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalUInt16_emitter),
+    TestSignalUInt16_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalUInt16_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalUInt16_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalUInt16_emitter));
-TestSignalInt16_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalInt16_emitter),
+    TestSignalInt16_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalInt16_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalInt16_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalInt16_emitter));
-TestSignalChar_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalChar_emitter),
+    TestSignalChar_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalChar_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalChar_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalChar_emitter));
-TestSignalBoolean_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalBoolean_emitter),
+    TestSignalBoolean_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalBoolean_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalBoolean_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalBoolean_emitter));
 }
@@ -1452,7 +1452,7 @@ bool org::gdbus::codegen::glibmm::TestStub::on_interface_set_property(
 }
 
 void org::gdbus::codegen::glibmm::TestStub::TestSignalByteStringArray_emitter(
-    const std::vector<Glib::ustring> &destination_bus_names,std::vector<std::string> Param1)
+    const std::vector<Glib::ustring> &destination_bus_names,const std::vector<std::string> & Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1473,7 +1473,7 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalByteStringArray_emitter(
 }
 
 void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(
-    const std::vector<Glib::ustring> &destination_bus_names,std::vector<Glib::DBusObjectPathString> Param1)
+    const std::vector<Glib::ustring> &destination_bus_names,const std::vector<Glib::DBusObjectPathString> & Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1494,7 +1494,7 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(
 }
 
 void org::gdbus::codegen::glibmm::TestStub::TestSignalStringArray_emitter(
-    const std::vector<Glib::ustring> &destination_bus_names,std::vector<Glib::ustring> Param1)
+    const std::vector<Glib::ustring> &destination_bus_names,const std::vector<Glib::ustring> & Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1515,7 +1515,7 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalStringArray_emitter(
 }
 
 void org::gdbus::codegen::glibmm::TestStub::TestSignalByteString_emitter(
-    const std::vector<Glib::ustring> &destination_bus_names,std::string Param1)
+    const std::vector<Glib::ustring> &destination_bus_names,const std::string & Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1536,7 +1536,7 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalByteString_emitter(
 }
 
 void org::gdbus::codegen::glibmm::TestStub::TestSignalSignature_emitter(
-    const std::vector<Glib::ustring> &destination_bus_names,Glib::DBusSignatureString Param1)
+    const std::vector<Glib::ustring> &destination_bus_names,const Glib::DBusSignatureString & Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1557,7 +1557,7 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalSignature_emitter(
 }
 
 void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPath_emitter(
-    const std::vector<Glib::ustring> &destination_bus_names,Glib::DBusObjectPathString Param1)
+    const std::vector<Glib::ustring> &destination_bus_names,const Glib::DBusObjectPathString & Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1578,7 +1578,7 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPath_emitter(
 }
 
 void org::gdbus::codegen::glibmm::TestStub::TestSignalString_emitter(
-    const std::vector<Glib::ustring> &destination_bus_names,Glib::ustring Param1)
+    const std::vector<Glib::ustring> &destination_bus_names,const Glib::ustring & Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -1786,7 +1786,6 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalBoolean_emitter(
         }
     }
 }
-
 
 
 bool org::gdbus::codegen::glibmm::TestStub::TestPropReadByteStringArray_set(const std::vector<std::string> & value)

--- a/tests/data/many-types/input_stub.h
+++ b/tests/data/many-types/input_stub.h
@@ -576,33 +576,33 @@ protected:
     virtual bool TestPropInternalReadWritePropertyChange_setHandler(gint32 value) = 0;
     virtual gint32 TestPropInternalReadWritePropertyChange_get() = 0;
 
-    void TestSignalByteStringArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::vector<std::string>);
-    sigc::signal<void, std::vector<std::string>> TestSignalByteStringArray_signal;
-    sigc::signal<void, const std::vector<Glib::ustring>&, std::vector<std::string>> TestSignalByteStringArray_selectiveSignal;
+    void TestSignalByteStringArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, const std::vector<std::string> &);
+    sigc::signal<void, const std::vector<std::string> &> TestSignalByteStringArray_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, const std::vector<std::string> &> TestSignalByteStringArray_selectiveSignal;
 
-    void TestSignalObjectPathArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::vector<Glib::DBusObjectPathString>);
-    sigc::signal<void, std::vector<Glib::DBusObjectPathString>> TestSignalObjectPathArray_signal;
-    sigc::signal<void, const std::vector<Glib::ustring>&, std::vector<Glib::DBusObjectPathString>> TestSignalObjectPathArray_selectiveSignal;
+    void TestSignalObjectPathArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, const std::vector<Glib::DBusObjectPathString> &);
+    sigc::signal<void, const std::vector<Glib::DBusObjectPathString> &> TestSignalObjectPathArray_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, const std::vector<Glib::DBusObjectPathString> &> TestSignalObjectPathArray_selectiveSignal;
 
-    void TestSignalStringArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::vector<Glib::ustring>);
-    sigc::signal<void, std::vector<Glib::ustring>> TestSignalStringArray_signal;
-    sigc::signal<void, const std::vector<Glib::ustring>&, std::vector<Glib::ustring>> TestSignalStringArray_selectiveSignal;
+    void TestSignalStringArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, const std::vector<Glib::ustring> &);
+    sigc::signal<void, const std::vector<Glib::ustring> &> TestSignalStringArray_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, const std::vector<Glib::ustring> &> TestSignalStringArray_selectiveSignal;
 
-    void TestSignalByteString_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::string);
-    sigc::signal<void, std::string> TestSignalByteString_signal;
-    sigc::signal<void, const std::vector<Glib::ustring>&, std::string> TestSignalByteString_selectiveSignal;
+    void TestSignalByteString_emitter(const std::vector<Glib::ustring> &destination_bus_names, const std::string &);
+    sigc::signal<void, const std::string &> TestSignalByteString_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, const std::string &> TestSignalByteString_selectiveSignal;
 
-    void TestSignalSignature_emitter(const std::vector<Glib::ustring> &destination_bus_names, Glib::DBusSignatureString);
-    sigc::signal<void, Glib::DBusSignatureString> TestSignalSignature_signal;
-    sigc::signal<void, const std::vector<Glib::ustring>&, Glib::DBusSignatureString> TestSignalSignature_selectiveSignal;
+    void TestSignalSignature_emitter(const std::vector<Glib::ustring> &destination_bus_names, const Glib::DBusSignatureString &);
+    sigc::signal<void, const Glib::DBusSignatureString &> TestSignalSignature_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, const Glib::DBusSignatureString &> TestSignalSignature_selectiveSignal;
 
-    void TestSignalObjectPath_emitter(const std::vector<Glib::ustring> &destination_bus_names, Glib::DBusObjectPathString);
-    sigc::signal<void, Glib::DBusObjectPathString> TestSignalObjectPath_signal;
-    sigc::signal<void, const std::vector<Glib::ustring>&, Glib::DBusObjectPathString> TestSignalObjectPath_selectiveSignal;
+    void TestSignalObjectPath_emitter(const std::vector<Glib::ustring> &destination_bus_names, const Glib::DBusObjectPathString &);
+    sigc::signal<void, const Glib::DBusObjectPathString &> TestSignalObjectPath_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, const Glib::DBusObjectPathString &> TestSignalObjectPath_selectiveSignal;
 
-    void TestSignalString_emitter(const std::vector<Glib::ustring> &destination_bus_names, Glib::ustring);
-    sigc::signal<void, Glib::ustring> TestSignalString_signal;
-    sigc::signal<void, const std::vector<Glib::ustring>&, Glib::ustring> TestSignalString_selectiveSignal;
+    void TestSignalString_emitter(const std::vector<Glib::ustring> &destination_bus_names, const Glib::ustring &);
+    sigc::signal<void, const Glib::ustring &> TestSignalString_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, const Glib::ustring &> TestSignalString_selectiveSignal;
 
     void TestSignalDouble_emitter(const std::vector<Glib::ustring> &destination_bus_names, double);
     sigc::signal<void, double> TestSignalDouble_signal;

--- a/tests/data/many-types/input_stub.h
+++ b/tests/data/many-types/input_stub.h
@@ -576,53 +576,69 @@ protected:
     virtual bool TestPropInternalReadWritePropertyChange_setHandler(gint32 value) = 0;
     virtual gint32 TestPropInternalReadWritePropertyChange_get() = 0;
 
-    void TestSignalByteStringArray_emitter(std::vector<std::string>);
+    void TestSignalByteStringArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::vector<std::string>);
     sigc::signal<void, std::vector<std::string>> TestSignalByteStringArray_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, std::vector<std::string>> TestSignalByteStringArray_selectiveSignal;
 
-    void TestSignalObjectPathArray_emitter(std::vector<Glib::DBusObjectPathString>);
+    void TestSignalObjectPathArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::vector<Glib::DBusObjectPathString>);
     sigc::signal<void, std::vector<Glib::DBusObjectPathString>> TestSignalObjectPathArray_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, std::vector<Glib::DBusObjectPathString>> TestSignalObjectPathArray_selectiveSignal;
 
-    void TestSignalStringArray_emitter(std::vector<Glib::ustring>);
+    void TestSignalStringArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::vector<Glib::ustring>);
     sigc::signal<void, std::vector<Glib::ustring>> TestSignalStringArray_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, std::vector<Glib::ustring>> TestSignalStringArray_selectiveSignal;
 
-    void TestSignalByteString_emitter(std::string);
+    void TestSignalByteString_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::string);
     sigc::signal<void, std::string> TestSignalByteString_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, std::string> TestSignalByteString_selectiveSignal;
 
-    void TestSignalSignature_emitter(Glib::DBusSignatureString);
+    void TestSignalSignature_emitter(const std::vector<Glib::ustring> &destination_bus_names, Glib::DBusSignatureString);
     sigc::signal<void, Glib::DBusSignatureString> TestSignalSignature_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, Glib::DBusSignatureString> TestSignalSignature_selectiveSignal;
 
-    void TestSignalObjectPath_emitter(Glib::DBusObjectPathString);
+    void TestSignalObjectPath_emitter(const std::vector<Glib::ustring> &destination_bus_names, Glib::DBusObjectPathString);
     sigc::signal<void, Glib::DBusObjectPathString> TestSignalObjectPath_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, Glib::DBusObjectPathString> TestSignalObjectPath_selectiveSignal;
 
-    void TestSignalString_emitter(Glib::ustring);
+    void TestSignalString_emitter(const std::vector<Glib::ustring> &destination_bus_names, Glib::ustring);
     sigc::signal<void, Glib::ustring> TestSignalString_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, Glib::ustring> TestSignalString_selectiveSignal;
 
-    void TestSignalDouble_emitter(double);
+    void TestSignalDouble_emitter(const std::vector<Glib::ustring> &destination_bus_names, double);
     sigc::signal<void, double> TestSignalDouble_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, double> TestSignalDouble_selectiveSignal;
 
-    void TestSignalUInt64_emitter(guint64);
+    void TestSignalUInt64_emitter(const std::vector<Glib::ustring> &destination_bus_names, guint64);
     sigc::signal<void, guint64> TestSignalUInt64_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, guint64> TestSignalUInt64_selectiveSignal;
 
-    void TestSignalInt64_emitter(gint64);
+    void TestSignalInt64_emitter(const std::vector<Glib::ustring> &destination_bus_names, gint64);
     sigc::signal<void, gint64> TestSignalInt64_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, gint64> TestSignalInt64_selectiveSignal;
 
-    void TestSignalUInt_emitter(guint32);
+    void TestSignalUInt_emitter(const std::vector<Glib::ustring> &destination_bus_names, guint32);
     sigc::signal<void, guint32> TestSignalUInt_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, guint32> TestSignalUInt_selectiveSignal;
 
-    void TestSignalInt_emitter(gint32);
+    void TestSignalInt_emitter(const std::vector<Glib::ustring> &destination_bus_names, gint32);
     sigc::signal<void, gint32> TestSignalInt_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, gint32> TestSignalInt_selectiveSignal;
 
-    void TestSignalUInt16_emitter(guint16);
+    void TestSignalUInt16_emitter(const std::vector<Glib::ustring> &destination_bus_names, guint16);
     sigc::signal<void, guint16> TestSignalUInt16_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, guint16> TestSignalUInt16_selectiveSignal;
 
-    void TestSignalInt16_emitter(gint16);
+    void TestSignalInt16_emitter(const std::vector<Glib::ustring> &destination_bus_names, gint16);
     sigc::signal<void, gint16> TestSignalInt16_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, gint16> TestSignalInt16_selectiveSignal;
 
-    void TestSignalChar_emitter(guchar);
+    void TestSignalChar_emitter(const std::vector<Glib::ustring> &destination_bus_names, guchar);
     sigc::signal<void, guchar> TestSignalChar_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, guchar> TestSignalChar_selectiveSignal;
 
-    void TestSignalBoolean_emitter(bool);
+    void TestSignalBoolean_emitter(const std::vector<Glib::ustring> &destination_bus_names, bool);
     sigc::signal<void, bool> TestSignalBoolean_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, bool> TestSignalBoolean_selectiveSignal;
 
     void on_method_call(const Glib::RefPtr<Gio::DBus::Connection> &connection,
                         const Glib::ustring &sender,

--- a/tests/data/simple/input_stub.cpp
+++ b/tests/data/simple/input_stub.cpp
@@ -52,7 +52,9 @@ inline std::string specialGetter(Glib::Variant<std::string> variant)
 org::gdbus::codegen::glibmm::TestStub::TestStub():
     m_interfaceName("org.gdbus.codegen.glibmm.Test")
 {
-    TestSignalObjectPathArray_signal.connect(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter));
+TestSignalObjectPathArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter),
+            std::vector<Glib::ustring>({""})) );
+    TestSignalObjectPathArray_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter));
 }
 
 org::gdbus::codegen::glibmm::TestStub::~TestStub()
@@ -169,7 +171,8 @@ bool org::gdbus::codegen::glibmm::TestStub::on_interface_set_property(
     return true;
 }
 
-void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(std::vector<Glib::DBusObjectPathString> Param1)
+void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(
+    const std::vector<Glib::ustring> &destination_bus_names,std::vector<Glib::DBusObjectPathString> Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -178,14 +181,17 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(st
     const Glib::VariantContainerBase params =
         Glib::Variant<std::vector<Glib::VariantBase>>::create_tuple(paramsList);
     for (const RegisteredObject &obj: m_registered_objects) {
-        obj.connection->emit_signal(
-            obj.object_path,
-            "org.gdbus.codegen.glibmm.Test",
-            "TestSignalObjectPathArray",
-            Glib::ustring(),
-            params);
+        for (const auto &bus_name: destination_bus_names) {
+            obj.connection->emit_signal(
+                    obj.object_path,
+                    "org.gdbus.codegen.glibmm.Test",
+                    "TestSignalObjectPathArray",
+                    bus_name,
+                    params);
+        }
     }
 }
+
 
 
 bool org::gdbus::codegen::glibmm::TestStub::TestPropReadStringArray_set(const std::vector<Glib::ustring> & value)

--- a/tests/data/simple/input_stub.cpp
+++ b/tests/data/simple/input_stub.cpp
@@ -52,7 +52,7 @@ inline std::string specialGetter(Glib::Variant<std::string> variant)
 org::gdbus::codegen::glibmm::TestStub::TestStub():
     m_interfaceName("org.gdbus.codegen.glibmm.Test")
 {
-TestSignalObjectPathArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter),
+    TestSignalObjectPathArray_signal.connect(sigc::bind<0>(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter),
             std::vector<Glib::ustring>({""})) );
     TestSignalObjectPathArray_selectiveSignal.connect(sigc::mem_fun(this, &TestStub::TestSignalObjectPathArray_emitter));
 }
@@ -172,7 +172,7 @@ bool org::gdbus::codegen::glibmm::TestStub::on_interface_set_property(
 }
 
 void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(
-    const std::vector<Glib::ustring> &destination_bus_names,std::vector<Glib::DBusObjectPathString> Param1)
+    const std::vector<Glib::ustring> &destination_bus_names,const std::vector<Glib::DBusObjectPathString> & Param1)
 {
     std::vector<Glib::VariantBase> paramsList;
 
@@ -191,7 +191,6 @@ void org::gdbus::codegen::glibmm::TestStub::TestSignalObjectPathArray_emitter(
         }
     }
 }
-
 
 
 bool org::gdbus::codegen::glibmm::TestStub::TestPropReadStringArray_set(const std::vector<Glib::ustring> & value)

--- a/tests/data/simple/input_stub.h
+++ b/tests/data/simple/input_stub.h
@@ -45,9 +45,9 @@ protected:
     virtual bool TestPropReadStringArray_setHandler(const std::vector<Glib::ustring> & value) = 0;
     virtual std::vector<Glib::ustring> TestPropReadStringArray_get() = 0;
 
-    void TestSignalObjectPathArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::vector<Glib::DBusObjectPathString>);
-    sigc::signal<void, std::vector<Glib::DBusObjectPathString>> TestSignalObjectPathArray_signal;
-    sigc::signal<void, const std::vector<Glib::ustring>&, std::vector<Glib::DBusObjectPathString>> TestSignalObjectPathArray_selectiveSignal;
+    void TestSignalObjectPathArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, const std::vector<Glib::DBusObjectPathString> &);
+    sigc::signal<void, const std::vector<Glib::DBusObjectPathString> &> TestSignalObjectPathArray_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, const std::vector<Glib::DBusObjectPathString> &> TestSignalObjectPathArray_selectiveSignal;
 
     void on_method_call(const Glib::RefPtr<Gio::DBus::Connection> &connection,
                         const Glib::ustring &sender,

--- a/tests/data/simple/input_stub.h
+++ b/tests/data/simple/input_stub.h
@@ -45,8 +45,9 @@ protected:
     virtual bool TestPropReadStringArray_setHandler(const std::vector<Glib::ustring> & value) = 0;
     virtual std::vector<Glib::ustring> TestPropReadStringArray_get() = 0;
 
-    void TestSignalObjectPathArray_emitter(std::vector<Glib::DBusObjectPathString>);
+    void TestSignalObjectPathArray_emitter(const std::vector<Glib::ustring> &destination_bus_names, std::vector<Glib::DBusObjectPathString>);
     sigc::signal<void, std::vector<Glib::DBusObjectPathString>> TestSignalObjectPathArray_signal;
+    sigc::signal<void, const std::vector<Glib::ustring>&, std::vector<Glib::DBusObjectPathString>> TestSignalObjectPathArray_selectiveSignal;
 
     void on_method_call(const Glib::RefPtr<Gio::DBus::Connection> &connection,
                         const Glib::ustring &sender,

--- a/tests/integration/common/many-types.xml
+++ b/tests/integration/common/many-types.xml
@@ -124,6 +124,10 @@
         <arg type="b" name="Param2" direction="out"></arg>
     </method>
 
+    <method name="TestSelectiveSignalTrigger">
+        <arg type="b" name="Param1" direction="in"></arg>
+    </method>
+
     <method name="TestAll">
         <arg type="aay" name="in_Param1"  direction="in"></arg>
         <arg type="ao"  name="in_Param2"  direction="in"></arg>
@@ -239,6 +243,10 @@
     </signal>
 
     <signal name="TestSignalBoolean">
+        <arg type="b" name="Param1"></arg>
+    </signal>
+
+    <signal name="TestSelectiveSignal">
         <arg type="b" name="Param1"></arg>
     </signal>
 

--- a/tests/integration/proxy/testproxymain.cpp
+++ b/tests/integration/proxy/testproxymain.cpp
@@ -543,6 +543,11 @@ void TestProxyImpl::on_test_signal_boolean_cb(const bool s) {
     record_signal();
 }
 
+void TestProxyImpl::on_test_selective_signal_cb(const bool s) {
+    printStatus("Signal TestSelectiveSignal", true);
+    record_signal();
+}
+
 void TestProxyImpl::on_notification_received()
 {
     m_pending_notifications--;
@@ -924,6 +929,12 @@ void TestProxyImpl::proxy_created(const Glib::RefPtr<Gio::AsyncResult> result) {
     m_proxy->TestSignalBoolean_signal.connect(
         sigc::mem_fun(this, &TestProxyImpl::on_test_signal_boolean_cb));
     m_pending_signals++;
+
+    /* Test Selective signal */
+    m_proxy->TestSelectiveSignal_signal.connect(
+        sigc::mem_fun(this, &TestProxyImpl::on_test_selective_signal_cb));
+    m_pending_signals++;
+    m_proxy->TestSelectiveSignalTrigger_sync(true);
 }
 
 void TestProxyImpl::record_signal()

--- a/tests/integration/proxy/testproxymain.h
+++ b/tests/integration/proxy/testproxymain.h
@@ -123,6 +123,9 @@ private:
     void on_test_signal_char_cb(const guchar s);
     void on_test_signal_boolean_cb(const bool s);
 
+    /* selective signal handler */
+    void on_test_selective_signal_cb(const bool s);
+
     void on_notification_received();
     void expect_notification(sigc::signal<void> &signal);
 

--- a/tests/integration/stub/teststubmain.cpp
+++ b/tests/integration/stub/teststubmain.cpp
@@ -227,6 +227,16 @@ void TestImpl::TestBoolean (
     invocation.ret(Param1);
 }
 
+void TestImpl::TestSelectiveSignalTrigger (
+        bool Param1,
+        MethodInvocation &invocation) {
+    std::vector<Glib::ustring> clientIds;
+    clientIds.emplace_back(invocation.getMessage()->get_sender());
+    TestSelectiveSignal_selectiveSignal(clientIds, Param1);
+
+    invocation.ret();
+}
+
 void TestImpl::TestAll (
         const std::vector<std::string> &in_Param1,
         const std::vector<Glib::DBusObjectPathString> &in_Param2,

--- a/tests/integration/stub/teststubmain.h
+++ b/tests/integration/stub/teststubmain.h
@@ -76,6 +76,9 @@ public:
     void TestBoolean (
             bool Param1,
             MethodInvocation &invocation) override;
+    void TestSelectiveSignalTrigger (
+            bool Param1,
+            MethodInvocation &invocation) override;
     void TestAll (
             const std::vector<std::string> &in_Param1,
             const std::vector<Glib::DBusObjectPathString> &in_Param2,


### PR DESCRIPTION
Some architecture needs to multicast  signal for subscriber / publisher model.
but XXX_signal connected emitter basically work on broadcast.

so adding selective signal method work on multicast with uniqueId list gathering from sender invocation data.
 