### PR TITLE
templates: Omit setter stubs for read-only properties

### DIFF
--- a/codegen_glibmm/templates/stub.cpp.templ
+++ b/codegen_glibmm/templates/stub.cpp.templ
@@ -206,7 +206,7 @@ void {{ class_name_with_namespace }}::{{ signal.name }}_emitter(
 }
 
 {% endfor %}
-{% for prop in interface.properties %}
+{% for prop in interface.properties if prop.writable %}
 
 bool {{ class_name_with_namespace }}::{{ prop.name }}_set({{ prop.cpptype_in }} value)
 {

--- a/codegen_glibmm/templates/stub.h.templ
+++ b/codegen_glibmm/templates/stub.h.templ
@@ -31,7 +31,7 @@ public:
 
     class MethodInvocation;
 
-{% for prop in interface.properties %}
+{% for prop in interface.properties if prop.writable %}
     bool {{ prop.name }}_set({{ prop.cpptype_in }} value);
 {% endfor %}
 protected:
@@ -44,12 +44,14 @@ protected:
 {% endfor %}
 {% for prop in interface.properties %}
 
+{% if prop.writable %}
     /* Handle the setting of a property
      * This method will be called as a result of a call to <PropName>_set
      * and should implement the actual setting of the property value.
      * Should return true on success and false otherwise.
      */
     virtual bool {{ prop.name }}_setHandler({{ prop.cpptype_in }} value) = 0;
+{% endif %}
     virtual {{ prop.cpptype_out }} {{ prop.name }}_get() = 0;
 {% endfor %}
 {% for signal in interface.signals %}


### PR DESCRIPTION
The generated code will have stubs for setters which I don't think should be there;
the properties are read-only and they should not need a setter.

Example
https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html
https://gitlab.freedesktop.org/mpris/mpris-spec/-/blob/master/spec/org.mpris.MediaPlayer2.Player.xml
